### PR TITLE
Refactor: Remove 'front.' prefix from frontend routes

### DIFF
--- a/app/Http/Controllers/FrontendController.php
+++ b/app/Http/Controllers/FrontendController.php
@@ -45,7 +45,7 @@ class FrontendController extends Controller
 
     public function contact_submit(\Illuminate\Http\Request $request)
     {
-        return redirect()->route('front.contact')->with('success', 'Your message has been sent successfully!');
+        return redirect()->route('contact')->with('success', 'Your message has been sent successfully!');
     }
 
     // terms-and-condition

--- a/resources/views/auth2/account-linked.blade.php
+++ b/resources/views/auth2/account-linked.blade.php
@@ -22,7 +22,7 @@
 
                 <div class="flex  gap-2">
 
-                    <a href="{{ route('front.home') }}" class="btn-outline-full">Back home</a>
+                    <a href="{{ route('home') }}" class="btn-outline-full">Back home</a>
 
                     <a href="{{ route('admin.dashboard.index') }}" class="btn-primary-full  ">Go to dashboard</a>
                 </div>

--- a/resources/views/components/frontend/project-card.blade.php
+++ b/resources/views/components/frontend/project-card.blade.php
@@ -1,9 +1,9 @@
  <div class=" flex flex-col gap-4 ">
-     <a href="{{ route('front.projects.show', $project->slug) }}">
+     <a href="{{ route('projects.show', $project->slug) }}">
          <img class="rounded-md w-full h-[340px] object-cover" src="{{ asset('upload/projects/') }}/{{ $project->thumbnail }}" alt="{{ $project->thumbnail }}">
      </a>
      <div>
-         <a href="{{ route('front.projects.show', $project->slug) }}">
+         <a href="{{ route('projects.show', $project->slug) }}">
              <h1 class="title-text-bold-medium text-secondary-950 line-clamp-1">{{ $project->title }}</h1>
          </a>
          <div class="flex gap-2 justify-between items-center mt-2">

--- a/resources/views/frontend/articles/index.blade.php
+++ b/resources/views/frontend/articles/index.blade.php
@@ -7,7 +7,7 @@
             Explore our least <span class="text-primary-600">Ariticles</span>
         </h1>
         <!-- Search Form -->
-        <form action="{{ route('front.articles.index') }}" method="GET" class="mt-8 md:mt-14">
+        <form action="{{ route('articles.index') }}" method="GET" class="mt-8 md:mt-14">
             <div class="flex flex-col md:flex-row justify-center items-center gap-4 md:gap-6">
                 <!-- Search Input -->
                 <div class="flex w-full md:w-[496px] items-center p-3 md:p-4 border border-secondary-400 rounded-lg">
@@ -61,7 +61,7 @@
                         <p class="body-text-regular-medium text-secondary-600 pt-1"> {{ $article->short_text }} </p>
                     </div>
 
-                    <a href="{{ route('front.articles.show', $article->slug) }}" class="inline-block px-3 py-2 rounded-sm border border-secondary-800 label-text-bold-small text-secondary-800 mt-4"> Read more </a>
+                    <a href="{{ route('articles.show', $article->slug) }}" class="inline-block px-3 py-2 rounded-sm border border-secondary-800 label-text-bold-small text-secondary-800 mt-4"> Read more </a>
                 </div>
             @empty
                 <h3 class="heading-text-regular-large text-secondary-800 m-auto">No Article available this area!</h3>

--- a/resources/views/frontend/articles/show.blade.php
+++ b/resources/views/frontend/articles/show.blade.php
@@ -125,7 +125,7 @@
                             <p class="body-text-regular-medium text-secondary-600 pt-1"> {{ $item->short_text }} </p>
                         </div>
 
-                        <a href="{{ route('front.articles.show', $item->slug) }}" class="inline-block px-3 py-2 rounded-sm border border-secondary-800 label-text-bold-small text-secondary-800 mt-4"> Read more </a>
+                        <a href="{{ route('articles.show', $item->slug) }}" class="inline-block px-3 py-2 rounded-sm border border-secondary-800 label-text-bold-small text-secondary-800 mt-4"> Read more </a>
                     </div>
                 @endforeach
             </div>

--- a/resources/views/frontend/careers/apply-question.blade.php
+++ b/resources/views/frontend/careers/apply-question.blade.php
@@ -11,7 +11,7 @@
             </p>
         </div>
 
-        <form action="{{ route('front.careers.apply.submit', $slug) }}" method="POST">
+        <form action="{{ route('careers.apply.submit', $slug) }}" method="POST">
             @csrf
 
             <div class="flex w-[808px] flex-col p-6 gap-6 border border-secondary-400 rounded-2xl m-auto mt-8 mb-20">

--- a/resources/views/frontend/careers/apply.blade.php
+++ b/resources/views/frontend/careers/apply.blade.php
@@ -9,7 +9,7 @@
                 details on file and reach out when a suitable opportunity arises. </p>
         </div>
 
-        <form action="{{ route('front.careers.apply.submit', $slug) }}" method="POST">
+        <form action="{{ route('careers.apply.submit', $slug) }}" method="POST">
             @csrf
 
             <input type="hidden" name="step" value="1">

--- a/resources/views/frontend/careers/index.blade.php
+++ b/resources/views/frontend/careers/index.blade.php
@@ -7,7 +7,7 @@
 
         <!-- search  -->
         <!-- Search Form -->
-        <form action="{{ route('front.careers.index') }}" method="GET">
+        <form action="{{ route('careers.index') }}" method="GET">
 
             <div class="flex justify-center gap-6 mt-14">
 
@@ -74,8 +74,8 @@
                     </div>
 
                     <div class="flex  items-center justify-between gap-4">
-                        <a href="{{ route('front.careers.show', $vacancy->slug) }}" class="flex-1 label-text-bold-medium text-secondary-600 text-center">Learn More</a>
-                        <a class=" px-3 py-2 rounded-sm border border-secondary-800 label-text-bold-small text-secondary-800 flex-1 flex justify-center" href="{{ route('front.careers.apply', $vacancy->slug) }}"> Apply Now </a>
+                        <a href="{{ route('careers.show', $vacancy->slug) }}" class="flex-1 label-text-bold-medium text-secondary-600 text-center">Learn More</a>
+                        <a class=" px-3 py-2 rounded-sm border border-secondary-800 label-text-bold-small text-secondary-800 flex-1 flex justify-center" href="{{ route('careers.apply', $vacancy->slug) }}"> Apply Now </a>
                     </div>
                 </div>
             @endforeach

--- a/resources/views/frontend/contact.blade.php
+++ b/resources/views/frontend/contact.blade.php
@@ -37,7 +37,7 @@
                 </div>
                 <div class="w-full md:w-1/2 px-4">
                     <div class="bg-white rounded-lg shadow-md p-8">
-                        <form action="{{ route('front.contact') }}" method="POST">
+                        <form action="{{ route('contact') }}" method="POST">
                             @csrf
                             <div class="mb-4">
                                 <label for="name" class="block text-gray-700 font-bold mb-2">Name</label>

--- a/resources/views/frontend/home.blade.php
+++ b/resources/views/frontend/home.blade.php
@@ -315,7 +315,7 @@
             @endforelse
         </div>
         <div class="flex justify-center items-center mt-14">
-            <a href="{{ route('front.projects.index') }}" class="button-label px-7 py-3 label-text-bold-large">Explore
+            <a href="{{ route('projects.index') }}" class="button-label px-7 py-3 label-text-bold-large">Explore
                 More</a>
         </div>
     </div>
@@ -357,7 +357,7 @@
         @endfor
     </div>
     <div class="flex justify-center items-center mt-14">
-        <a href="{{ route('front.services.index') }}" class="button-label px-7 py-3 label-text-bold-large">See all
+        <a href="{{ route('services.index') }}" class="button-label px-7 py-3 label-text-bold-large">See all
             service</a>
     </div>
 </div>
@@ -400,7 +400,7 @@
     @endfor
 </div>
 <div class="flex justify-center items-center mt-14">
-    <a href="{{ route('front.softwares.index') }}" class="button-label px-7 py-3 label-text-bold-large">See details</a>
+    <a href="{{ route('softwares.index') }}" class="button-label px-7 py-3 label-text-bold-large">See details</a>
 </div>
 </div>
 {{-- Software's Solution --}}
@@ -658,7 +658,7 @@
                 <h2 class="title-text-bold-medium text-secondary-950 pt-2">{{ $article_data->title }}</h2>
                 <p class="body-text-regular-medium text-secondary-600 pt-1">{{ $article_data->short_text }}</p>
             </div>
-            <a href="{{ route('front.articles.show', $article_data->slug) }}"
+            <a href="{{ route('articles.show', $article_data->slug) }}"
                 class="inline-block px-3 py-2 rounded-sm border border-secondary-800 label-text-bold-small text-secondary-800 mt-4">Read
                 more</a>
         </div>

--- a/resources/views/frontend/layouts/footer.blade.php
+++ b/resources/views/frontend/layouts/footer.blade.php
@@ -33,13 +33,13 @@
                             <li class="label-text-regular-small text-secondary-900"><a
                                     href="{{ route('admin.dashboard.index') }}">Log in dashboard</a></li>
                             <li class="label-text-regular-small text-secondary-900"><a
-                                    href="{{ route('front.about') }}">About us</a></li>
+                                    href="{{ route('about') }}">About us</a></li>
                             <li class="label-text-regular-small text-secondary-900"><a
-                                    href="{{ route('front.contact') }}">Contact us</a></li>
+                                    href="{{ route('contact') }}">Contact us</a></li>
                             <li class="label-text-regular-small text-secondary-900"><a
-                                    href="{{ route('front.articles.index') }}">Articles</a></li>
+                                    href="{{ route('articles.index') }}">Articles</a></li>
                             <li class="label-text-regular-small text-secondary-900"><a
-                                    href="{{ route('front.careers.index') }}">Career</a></li>
+                                    href="{{ route('careers.index') }}">Career</a></li>
                             <li class="label-text-regular-small text-secondary-900"><a
                                     href="{{ route('privacy-policy') }}">Privacy policy</a></li>
                             <li class="label-text-regular-small text-secondary-900"><a
@@ -51,7 +51,7 @@
                         <ul class="flex flex-col gap-2 md:gap-3 pt-4">
                             @forelse ($services as $service)
                                 <li class="label-text-regular-small text-secondary-900"><a
-                                        href="{{ route('front.services.show', $service->slug) }}">{{ $service->title }}</a>
+                                        href="{{ route('services.show', $service->slug) }}">{{ $service->title }}</a>
                                 </li>
                             @empty
                                 <li class="label-text-regular-small text-secondary-900">No Service Found</li>
@@ -63,7 +63,7 @@
                         <ul class="flex flex-col gap-2 md:gap-3 pt-4">
                             @forelse ($softwares as $software)
                                 <li class="label-text-regular-small text-secondary-900"><a
-                                        href="{{ route('front.softwares.show', $software->slug) }}">{{ $software->title }}</a>
+                                        href="{{ route('softwares.show', $software->slug) }}">{{ $software->title }}</a>
                                 </li>
                             @empty
                                 <li class="label-text-regular-small text-secondary-900">No Software Found</li>

--- a/resources/views/frontend/layouts/navbar.blade.php
+++ b/resources/views/frontend/layouts/navbar.blade.php
@@ -1,17 +1,17 @@
 <nav class="shadow-[0px_2px_16px_0px_rgba(66,67,72,0.12)]" x-data="{ open: false }">
     <div class="container flex justify-between items-center h-20">
         {{-- Logo --}}
-        <a href="{{ route('front.home') }}">
+        <a href="{{ route('home') }}">
             <img src="{{ asset('frontend/images/logo.png') }}" alt="">
         </a>
 
         {{-- Menus --}}
         <ul class="hidden lg:flex justify-center items-center gap-7">
-            <li class="nav-item {{ request()->is('/') ? 'active' : '' }}"><a href="{{ route('front.home') }}">Home</a></li>
-            <li class="nav-item {{ request()->is('services') || request()->is('services/*') ? 'active' : '' }}"><a href="{{ route('front.services.index') }}">Services</a></li>
-            <li class="nav-item {{ request()->is('softwares') || request()->is('software/*') ? 'active' : '' }}"><a href="{{ route('front.softwares.index') }}">Software</a></li>
-            <li class="nav-item {{ request()->is('projects') || request()->is('projects/*') ? 'active' : '' }}"><a href="{{ route('front.projects.index') }}">Projects</a></li>
-            <li class="nav-item {{ request()->is('contact') ? 'active' : '' }}"><a href="{{ route('front.contact') }}">Contact us</a></li>
+            <li class="nav-item {{ request()->is('/') ? 'active' : '' }}"><a href="{{ route('home') }}">Home</a></li>
+            <li class="nav-item {{ request()->is('services') || request()->is('services/*') ? 'active' : '' }}"><a href="{{ route('services.index') }}">Services</a></li>
+            <li class="nav-item {{ request()->is('softwares') || request()->is('software/*') ? 'active' : '' }}"><a href="{{ route('softwares.index') }}">Software</a></li>
+            <li class="nav-item {{ request()->is('projects') || request()->is('projects/*') ? 'active' : '' }}"><a href="{{ route('projects.index') }}">Projects</a></li>
+            <li class="nav-item {{ request()->is('contact') ? 'active' : '' }}"><a href="{{ route('contact') }}">Contact us</a></li>
         </ul>
 
         {{-- Login Btn --}}
@@ -33,11 +33,11 @@
     {{-- Mobile Menu --}}
     <div x-show="open" class="lg:hidden" x-transition:enter="transition ease-out duration-300" x-transition:enter-start="opacity-0 transform -translate-y-2" x-transition:enter-end="opacity-100 transform translate-y-0" x-transition:leave="transition ease-in duration-200" x-transition:leave-start="opacity-100 transform translate-y-0" x-transition:leave-end="opacity-0 transform -translate-y-2">
         <ul class="flex flex-col items-center gap-4 py-4">
-            <li class="nav-item {{ request()->is('/') ? 'active' : '' }}"><a href="{{ route('front.home') }}">Home</a></li>
-            <li class="nav-item {{ request()->is('services') || request()->is('services/*') ? 'active' : '' }}"><a href="{{ route('front.services.index') }}">Services</a></li>
-            <li class="nav-item {{ request()->is('softwares') || request()->is('software/*') ? 'active' : '' }}"><a href="{{ route('front.softwares.index') }}">Software</a></li>
-            <li class="nav-item {{ request()->is('projects') || request()->is('projects/*') ? 'active' : '' }}"><a href="{{ route('front.projects.index') }}">Projects</a></li>
-            <li class="nav-item {{ request()->is('contact') ? 'active' : '' }}"><a href="{{ route('front.contact') }}">Contact us</a></li>
+            <li class="nav-item {{ request()->is('/') ? 'active' : '' }}"><a href="{{ route('home') }}">Home</a></li>
+            <li class="nav-item {{ request()->is('services') || request()->is('services/*') ? 'active' : '' }}"><a href="{{ route('services.index') }}">Services</a></li>
+            <li class="nav-item {{ request()->is('softwares') || request()->is('software/*') ? 'active' : '' }}"><a href="{{ route('softwares.index') }}">Software</a></li>
+            <li class="nav-item {{ request()->is('projects') || request()->is('projects/*') ? 'active' : '' }}"><a href="{{ route('projects.index') }}">Projects</a></li>
+            <li class="nav-item {{ request()->is('contact') ? 'active' : '' }}"><a href="{{ route('contact') }}">Contact us</a></li>
             <li><a href="{{ route('login') }}" class="label-text-bold-medium text-secondary-800 border border-secondary-800 rounded-[6px] px-4 py-2">Login</a></li>
             <li><a href="#" class="label-text-bold-medium text-white bg-primary-600 rounded-[6px] px-4 py-2">Whatsapp us</a></li>
         </ul>

--- a/resources/views/frontend/projects/index.blade.php
+++ b/resources/views/frontend/projects/index.blade.php
@@ -7,7 +7,7 @@
             Explore our least <span class="text-primary-600">Projects</span>
         </h1>
         <!-- Search Form -->
-        <form action="{{ route('front.projects.index') }}" method="GET" class="mt-8 md:mt-14">
+        <form action="{{ route('projects.index') }}" method="GET" class="mt-8 md:mt-14">
             <div class="flex flex-col md:flex-row justify-center items-center gap-4 md:gap-6">
                 <!-- Search Input -->
                 <div class="flex w-full md:w-[496px] items-center p-3 md:p-4 border border-secondary-400 rounded-lg">

--- a/resources/views/frontend/services/index.blade.php
+++ b/resources/views/frontend/services/index.blade.php
@@ -7,7 +7,7 @@
             Explore our least <span class="text-primary-600">Services</span>
         </h1>
         <!-- Search Form -->
-        <form action="{{ route('front.services.index') }}" method="GET" class="mt-8 md:mt-14">
+        <form action="{{ route('services.index') }}" method="GET" class="mt-8 md:mt-14">
             <div class="flex flex-col md:flex-row justify-center items-center gap-4 md:gap-6">
                 <!-- Search Input -->
                 <div class="flex w-full md:w-[496px] items-center p-3 md:p-4 border border-secondary-400 rounded-lg">
@@ -61,7 +61,7 @@
                         <p class="body-text-regular-medium text-secondary-600 pt-1"> {{ $service->short_text }} </p>
                     </div>
 
-                    <a href="{{ route('front.services.show', $service->slug) }}" class="inline-block px-3 py-2 rounded-sm border border-secondary-800 label-text-bold-small text-secondary-800 mt-4"> Read more </a>
+                    <a href="{{ route('services.show', $service->slug) }}" class="inline-block px-3 py-2 rounded-sm border border-secondary-800 label-text-bold-small text-secondary-800 mt-4"> Read more </a>
                 </div>
             @empty
                 <h3 class="heading-text-regular-large text-secondary-800 m-auto">No service available this area!</h3>

--- a/resources/views/frontend/services/show.blade.php
+++ b/resources/views/frontend/services/show.blade.php
@@ -125,7 +125,7 @@
                             <p class="body-text-regular-medium text-secondary-600 pt-1"> {{ $item->short_text }} </p>
                         </div>
 
-                        <a href="{{ route('front.articles.show', $item->slug) }}" class="inline-block px-3 py-2 rounded-sm border border-secondary-800 label-text-bold-small text-secondary-800 mt-4"> Read more </a>
+                        <a href="{{ route('articles.show', $item->slug) }}" class="inline-block px-3 py-2 rounded-sm border border-secondary-800 label-text-bold-small text-secondary-800 mt-4"> Read more </a>
                     </div>
                 @endforeach
             </div>

--- a/resources/views/frontend/softwares/index.blade.php
+++ b/resources/views/frontend/softwares/index.blade.php
@@ -7,7 +7,7 @@
             Explore our least <span class="text-primary-600">Softwares</span>
         </h1>
         <!-- Search Form -->
-        <form action="{{ route('front.softwares.index') }}" method="GET" class="mt-8 md:mt-14">
+        <form action="{{ route('softwares.index') }}" method="GET" class="mt-8 md:mt-14">
             <div class="flex flex-col md:flex-row justify-center items-center gap-4 md:gap-6">
                 <!-- Search Input -->
                 <div class="flex w-full md:w-[496px] items-center p-3 md:p-4 border border-secondary-400 rounded-lg">
@@ -61,7 +61,7 @@
                         <p class="body-text-regular-medium text-secondary-600 pt-1"> {{ $software->short_text }} </p>
                     </div>
 
-                    <a href="{{ route('front.softwares.show', $software->slug) }}" class="inline-block px-3 py-2 rounded-sm border border-secondary-800 label-text-bold-small text-secondary-800 mt-4"> Read more </a>
+                    <a href="{{ route('softwares.show', $software->slug) }}" class="inline-block px-3 py-2 rounded-sm border border-secondary-800 label-text-bold-small text-secondary-800 mt-4"> Read more </a>
                 </div>
             @empty
                 <h3 class="heading-text-regular-large text-secondary-800 m-auto">No software available this area!</h3>

--- a/resources/views/frontend/softwares/show.blade.php
+++ b/resources/views/frontend/softwares/show.blade.php
@@ -125,7 +125,7 @@
                             <p class="body-text-regular-medium text-secondary-600 pt-1"> {{ $item->short_text }} </p>
                         </div>
 
-                        <a href="{{ route('front.articles.show', $item->slug) }}" class="inline-block px-3 py-2 rounded-sm border border-secondary-800 label-text-bold-small text-secondary-800 mt-4"> Read more </a>
+                        <a href="{{ route('articles.show', $item->slug) }}" class="inline-block px-3 py-2 rounded-sm border border-secondary-800 label-text-bold-small text-secondary-800 mt-4"> Read more </a>
                     </div>
                 @endforeach
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -39,6 +39,10 @@ Route::middleware('auth')->group(function () {
 // Frontend Routes =====================================================================
 Route::controller(FrontendController::class)->group(
     function () {
+        Route::get('/', 'home')->name('home');
+        Route::get('/about', 'about')->name('about');
+        Route::get('/contact', 'contact')->name('contact');
+        Route::post('/contact', 'contact_submit')->name('contact.submit');
         Route::get('/services', 'services')->name('services');
         Route::get('/software', 'software')->name('software');
         Route::get('/projects', 'projects')->name('projects');
@@ -62,24 +66,15 @@ Route::controller(FrontendController::class)->group(
     }
 );
 
-Route::name('front.')->group(function () {
-    Route::controller(FrontendController::class)->group(
-        function () {
-            Route::get('/', 'home')->name('home');
-            Route::get('/about', 'about')->name('about');
-            Route::get('/contact', 'contact')->name('contact');
-            Route::post('/contact', 'contact_submit')->name('contact.submit');
-        }
-    );
-    Route::resource('projects', ProjectFrontController::class)->only(['index', 'show'])->scoped(['project' => 'slug']);
-    Route::resource('services', ServiceFrontController::class)->only(['index', 'show'])->scoped(['service' => 'slug']);
-    Route::resource('softwares', SoftwareFrontController::class)->only(['index', 'show'])->scoped(['software' => 'slug']);
-    Route::resource('articles', ArticleFrontController::class)->only(['index', 'show'])->scoped(['article' => 'slug']);
+Route::resource('projects', ProjectFrontController::class)->only(['index', 'show'])->scoped(['project' => 'slug']);
+Route::resource('services', ServiceFrontController::class)->only(['index', 'show'])->scoped(['service' => 'slug']);
+Route::resource('softwares', SoftwareFrontController::class)->only(['index', 'show'])->scoped(['software' => 'slug']);
+Route::resource('articles', ArticleFrontController::class)->only(['index', 'show'])->scoped(['article' => 'slug']);
 
-    Route::resource('careers', CareerFrontController::class)->only(['index', 'show'])->scoped(['career' => 'slug']);
-    Route::get('/careers/apply/{slug}', [CareerFrontController::class, 'apply'])->name('careers.apply');
-    Route::post('/careers/apply/{slug}', [CareerFrontController::class, 'apply_submit'])->name('careers.apply.submit');
-});
+Route::resource('careers', CareerFrontController::class)->only(['index', 'show'])->scoped(['career' => 'slug']);
+Route::get('/careers/apply/{slug}', [CareerFrontController::class, 'apply'])->name('careers.apply');
+Route::post('/careers/apply/{slug}', [CareerFrontController::class, 'apply_submit'])->name('careers.apply.submit');
+
 
 Route::name('admin.')->prefix('admin')->middleware(['auth'])->group(function () {
     Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard.index');


### PR DESCRIPTION
Removes the 'front.' name prefix from all frontend routes to simplify route naming.

- Updated `routes/web.php` to remove the route name group.
- Updated all `route()` calls in Blade templates to use the new, shorter route names.
- Updated the `redirect()` call in `FrontendController` to align with the new route name.

Admin routes were left unchanged to adhere to the scope of the request.