### PR TITLE
feat: Implement frontend service and software plans sections

### DIFF
--- a/app/Http/Controllers/Admin/KeyFeatureController.php
+++ b/app/Http/Controllers/Admin/KeyFeatureController.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Controllers\Traits\FileUploadTrait;
+use App\Http\Requests\StoreKeyFeatureRequest;
+use App\Http\Requests\UpdateKeyFeatureRequest;
+use App\Models\KeyFeature;
+use Illuminate\Http\Request;
+
+class KeyFeatureController extends Controller
+{
+    use FileUploadTrait;
+
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        $keyFeatures = KeyFeature::latest()->get();
+        return view('admin.key_features.index', compact('keyFeatures'));
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        return view('admin.key_features.create');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(StoreKeyFeatureRequest $request)
+    {
+        $data = $request->validated();
+        $data['image'] = $this->uploadFile($request, 'image', 'key_features');
+        KeyFeature::create($data);
+        return redirect()->route('admin.key_features.index')->with('success', 'Key Feature created successfully.');
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(KeyFeature $keyFeature)
+    {
+        return view('admin.key_features.show', compact('keyFeature'));
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(KeyFeature $keyFeature)
+    {
+        return view('admin.key_features.edit', compact('keyFeature'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(UpdateKeyFeatureRequest $request, KeyFeature $keyFeature)
+    {
+        $data = $request->validated();
+        if ($request->hasFile('image')) {
+            $data['image'] = $this->updateFile($request, 'image', 'key_features', $keyFeature->image);
+        }
+        $keyFeature->update($data);
+        return redirect()->route('admin.key_features.index')->with('success', 'Key Feature updated successfully.');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(KeyFeature $keyFeature)
+    {
+        if ($keyFeature->image) {
+            $this->deleteFile('key_features', $keyFeature->image);
+        }
+        $keyFeature->delete();
+        return redirect()->route('admin.key_features.index')->with('success', 'Key Feature deleted successfully.');
+    }
+}

--- a/app/Http/Controllers/Admin/TechnologyController.php
+++ b/app/Http/Controllers/Admin/TechnologyController.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Controllers\Traits\FileUploadTrait;
+use App\Http\Requests\StoreTechnologyRequest;
+use App\Http\Requests\UpdateTechnologyRequest;
+use App\Models\Technology;
+use Illuminate\Http\Request;
+
+class TechnologyController extends Controller
+{
+    use FileUploadTrait;
+
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        $technologies = Technology::latest()->get();
+        return view('admin.technologies.index', compact('technologies'));
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        return view('admin.technologies.create');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(StoreTechnologyRequest $request)
+    {
+        $data = $request->validated();
+        $data['image'] = $this->uploadFile($request, 'image', 'technologies');
+        Technology::create($data);
+        return redirect()->route('admin.technologies.index')->with('success', 'Technology created successfully.');
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Technology $technology)
+    {
+        return view('admin.technologies.show', compact('technology'));
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(Technology $technology)
+    {
+        return view('admin.technologies.edit', compact('technology'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(UpdateTechnologyRequest $request, Technology $technology)
+    {
+        $data = $request->validated();
+        if ($request->hasFile('image')) {
+            $data['image'] = $this->updateFile($request, 'image', 'technologies', $technology->image);
+        }
+        $technology->update($data);
+        return redirect()->route('admin.technologies.index')->with('success', 'Technology updated successfully.');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Technology $technology)
+    {
+        if ($technology->image) {
+            $this->deleteFile('technologies', $technology->image);
+        }
+        $technology->delete();
+        return redirect()->route('admin.technologies.index')->with('success', 'Technology deleted successfully.');
+    }
+}

--- a/app/Http/Controllers/Frontend/ServiceFrontController.php
+++ b/app/Http/Controllers/Frontend/ServiceFrontController.php
@@ -27,7 +27,7 @@ class ServiceFrontController extends Controller
 
     public function show(Service $service)
     {
-        $service->load('service_category:id,title');
+        $service->load('service_category:id,title', 'keyFeatures', 'technologies', 'serviceTypes.pricePlans');
         $services = Service::with('service_category:id,title')->limit(5)->get();
 
         return view('frontend.services.show', ['services' => $services, 'service' => $service]);

--- a/app/Http/Controllers/Frontend/SoftwareFrontController.php
+++ b/app/Http/Controllers/Frontend/SoftwareFrontController.php
@@ -27,9 +27,10 @@ class SoftwareFrontController extends Controller
 
     public function show(Software $software)
     {
-        $software->load('software_category:id,title');
+        $software->load('software_category:id,title', 'keyFeatures', 'technologies', 'pricePlans');
         $softwares = Software::with('software_category:id,title')->limit(5)->get();
+        $groupedPricePlans = $software->pricePlans->groupBy('type');
 
-        return view('frontend.softwares.show', ['softwares' => $softwares, 'software' => $software]);
+        return view('frontend.softwares.show', ['softwares' => $softwares, 'software' => $software, 'groupedPricePlans' => $groupedPricePlans]);
     }
 }

--- a/app/Http/Requests/StoreKeyFeatureRequest.php
+++ b/app/Http/Requests/StoreKeyFeatureRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreKeyFeatureRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'description' => 'required|string',
+            'image' => 'required|image|mimes:jpeg,png,jpg,gif,svg|max:2048',
+        ];
+    }
+}

--- a/app/Http/Requests/StoreTechnologyRequest.php
+++ b/app/Http/Requests/StoreTechnologyRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreTechnologyRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'description' => 'required|string',
+            'image' => 'required|image|mimes:jpeg,png,jpg,gif,svg|max:2048',
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateKeyFeatureRequest.php
+++ b/app/Http/Requests/UpdateKeyFeatureRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateKeyFeatureRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'description' => 'required|string',
+            'image' => 'nullable|image|mimes:jpeg,png,jpg,gif,svg|max:2048',
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateTechnologyRequest.php
+++ b/app/Http/Requests/UpdateTechnologyRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateTechnologyRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'description' => 'required|string',
+            'image' => 'nullable|image|mimes:jpeg,png,jpg,gif,svg|max:2048',
+        ];
+    }
+}

--- a/app/Models/KeyFeature.php
+++ b/app/Models/KeyFeature.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class KeyFeature extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'description',
+        'image',
+    ];
+
+    /**
+     * Get all of the services that are assigned this key feature.
+     */
+    public function services()
+    {
+        return $this->morphedByMany(Service::class, 'key_featureable');
+    }
+
+    /**
+     * Get all of the softwares that are assigned this key feature.
+     */
+    public function softwares()
+    {
+        return $this->morphedByMany(Software::class, 'key_featureable');
+    }
+}

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -25,4 +25,14 @@ class Service extends Model
     {
         return $this->hasMany(ServiceType::class);
     }
+
+    public function technologies()
+    {
+        return $this->morphToMany(Technology::class, 'technologable');
+    }
+
+    public function keyFeatures()
+    {
+        return $this->morphToMany(KeyFeature::class, 'key_featureable');
+    }
 }

--- a/app/Models/Software.php
+++ b/app/Models/Software.php
@@ -27,4 +27,14 @@ class Software extends Model
     {
         return $this->morphMany(PricePlan::class, 'planable');
     }
+
+    public function technologies()
+    {
+        return $this->morphToMany(Technology::class, 'technologable');
+    }
+
+    public function keyFeatures()
+    {
+        return $this->morphToMany(KeyFeature::class, 'key_featureable');
+    }
 }

--- a/app/Models/Technology.php
+++ b/app/Models/Technology.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Technology extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'description',
+        'image',
+    ];
+
+    public function services()
+    {
+        return $this->morphedByMany(Service::class, 'technologable');
+    }
+
+    public function softwares()
+    {
+        return $this->morphedByMany(Software::class, 'technologable');
+    }
+}

--- a/database/migrations/2024_07_26_000000_create_key_features_table.php
+++ b/database/migrations/2024_07_26_000000_create_key_features_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('key_features', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->text('description');
+            $table->string('image')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('key_features');
+    }
+};

--- a/database/migrations/2024_07_26_000001_create_key_featureables_table.php
+++ b/database/migrations/2024_07_26_000001_create_key_featureables_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('key_featureables', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('key_feature_id')->constrained()->onDelete('cascade');
+            $table->morphs('key_featureable');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('key_featureables');
+    }
+};

--- a/database/migrations/2025_10_25_211530_create_technologies_table.php
+++ b/database/migrations/2025_10_25_211530_create_technologies_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('technologies', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->text('description');
+            $table->string('image');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('technologies');
+    }
+};

--- a/database/migrations/2025_10_25_211535_create_technologables_table.php
+++ b/database/migrations/2025_10_25_211535_create_technologables_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('technologables', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('technology_id')->constrained()->onDelete('cascade');
+            $table->morphs('technologable');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('technologables');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -28,6 +28,8 @@ class DatabaseSeeder extends Seeder
             ServiceSeeder::class,
             ServiceTypeSeeder::class,
             SoftwareCategorySeeder::class,
+            TechnologySeeder::class,
+            KeyFeatureSeeder::class,
             SoftwareSeeder::class,
             TeamSeeder::class,
             TrustedCompanySeeder::class,

--- a/database/seeders/KeyFeatureSeeder.php
+++ b/database/seeders/KeyFeatureSeeder.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\KeyFeature;
+use App\Models\Service;
+use App\Models\Software;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class KeyFeatureSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $keyFeatures = [
+            [
+                'name' => 'Responsive Design',
+                'description' => 'Our websites adjust seamlessly to all devices, delivering a consistent and optimized user experience across desktops, tablets, and smartphones.',
+                'image' => 'responsive-design.jpg',
+            ],
+            [
+                'name' => 'Fast Load Speed',
+                'description' => 'We optimize images, leverage browser caching, and minify CSS, JavaScript, and HTML to deliver a lightning-fast user experience.',
+                'image' => 'fast-load-speed.jpg',
+            ],
+            [
+                'name' => 'Advanced Security',
+                'description' => 'We implement security best practices, including SSL certificates, secure authentication, and protection against common vulnerabilities.',
+                'image' => 'advanced-security.jpg',
+            ],
+            [
+                'name' => 'Customizable CMS',
+                'description' => 'Our websites are built on a customizable content management system that allows you to easily update your website content.',
+                'image' => 'customizable-cms.jpg',
+            ],
+            [
+                'name' => 'Integrated Analytics',
+                'description' => 'We integrate Google Analytics to provide you with valuable insights into your website traffic and user behavior.',
+                'image' => 'integrated-analytics.jpg',
+            ],
+        ];
+
+        foreach ($keyFeatures as $keyFeature) {
+            KeyFeature::updateOrCreate(['name' => $keyFeature['name']], $keyFeature);
+        }
+
+        $services = Service::all();
+        $softwares = Software::all();
+        $keyFeatures = KeyFeature::pluck('id');
+
+        foreach ($services as $service) {
+            $service->keyFeatures()->sync($keyFeatures->random(rand(2, 4)));
+        }
+
+        foreach ($softwares as $software) {
+            $software->keyFeatures()->sync($keyFeatures->random(rand(2, 4)));
+        }
+    }
+}

--- a/database/seeders/TechnologySeeder.php
+++ b/database/seeders/TechnologySeeder.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Service;
+use App\Models\Software;
+use App\Models\Technology;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class TechnologySeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $technologies = [
+            [
+                'name' => 'Front-End Development',
+                'description' => 'HTML, CSS, JavaScript: Core technologies for responsive and engaging designs. Frameworks: React.js, Angular, and Vue.js for creating dynamic user interfaces.',
+                'image' => 'frontend.jpg',
+            ],
+            [
+                'name' => 'Back-End Development',
+                'description' => 'Programming Languages: Node.js, Python, PHP, Ruby on Rails for server-side logic. Databases: MySQL, PostgreSQL, MongoDB for secure and efficient data storage.',
+                'image' => 'backend.jpg',
+            ],
+            [
+                'name' => 'Content Management Systems (CMS)',
+                'description' => 'WordPress, Drupal, and Joomla for easy content management and updates.',
+                'image' => 'cms.jpg',
+            ],
+            [
+                'name' => 'Hosting and Deployment',
+                'description' => 'AWS, Google Cloud, and Microsoft Azure for reliable and scalable hosting. Docker and Kubernetes for seamless deployment and scalability.',
+                'image' => 'hosting.jpg',
+            ],
+            [
+                'name' => 'SEO Tools and Integration',
+                'description' => 'Yoast SEO, Ahrefs, and SEMrush for search engine optimization and analytics.',
+                'image' => 'seo.jpg',
+            ],
+            [
+                'name' => 'Analytics and Tracking',
+                'description' => 'Google Analytics, Hotjar, and Mixpanel for real-time tracking and user behavior analysis.',
+                'image' => 'analytics.jpg',
+            ],
+        ];
+
+        foreach ($technologies as $technology) {
+            Technology::updateOrCreate(['name' => $technology['name']], $technology);
+        }
+
+        $services = Service::all();
+        $softwares = Software::all();
+        $technologies = Technology::pluck('id');
+
+        foreach ($services as $service) {
+            $service->technologies()->sync($technologies->random(rand(2, 4)));
+        }
+
+        foreach ($softwares as $software) {
+            $software->technologies()->sync($technologies->random(rand(2, 4)));
+        }
+    }
+}

--- a/resources/views/admin/key_features/create.blade.php
+++ b/resources/views/admin/key_features/create.blade.php
@@ -1,0 +1,45 @@
+@extends('admin.layouts.app')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title">Create Key Feature</h3>
+                    </div>
+                    <!-- /.card-header -->
+                    <div class="card-body">
+                        <form action="{{ route('admin.key-features.store') }}" method="POST" enctype="multipart/form-data">
+                            @csrf
+                            <div class="form-group">
+                                <label for="name">Name</label>
+                                <input type="text" name="name" id="name" class="form-control"
+                                    value="{{ old('name') }}">
+                                @error('name')
+                                    <span class="text-danger">{{ $message }}</span>
+                                @enderror
+                            </div>
+                            <div class="form-group">
+                                <label for="description">Description</label>
+                                <textarea name="description" id="description" class="form-control">{{ old('description') }}</textarea>
+                                @error('description')
+                                    <span class="text-danger">{{ $message }}</span>
+                                @enderror
+                            </div>
+                            <div class="form-group">
+                                <label for="image">Image</label>
+                                <input type="file" name="image" id="image" class="form-control">
+                                @error('image')
+                                    <span class="text-danger">{{ $message }}</span>
+                                @enderror
+                            </div>
+                            <button type="submit" class="btn btn-primary">Create</button>
+                        </form>
+                    </div>
+                    <!-- /.card-body -->
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/key_features/edit.blade.php
+++ b/resources/views/admin/key_features/edit.blade.php
@@ -1,0 +1,51 @@
+@extends('admin.layouts.app')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title">Edit Key Feature</h3>
+                    </div>
+                    <!-- /.card-header -->
+                    <div class="card-body">
+                        <form action="{{ route('admin.key-features.update', $keyFeature->id) }}" method="POST"
+                            enctype="multipart/form-data">
+                            @csrf
+                            @method('PUT')
+                            <div class="form-group">
+                                <label for="name">Name</label>
+                                <input type="text" name="name" id="name" class="form-control"
+                                    value="{{ old('name', $keyFeature->name) }}">
+                                @error('name')
+                                    <span class="text-danger">{{ $message }}</span>
+                                @enderror
+                            </div>
+                            <div class="form-group">
+                                <label for="description">Description</label>
+                                <textarea name="description" id="description" class="form-control">{{ old('description', $keyFeature->description) }}</textarea>
+                                @error('description')
+                                    <span class="text-danger">{{ $message }}</span>
+                                @enderror
+                            </div>
+                            <div class="form-group">
+                                <label for="image">Image</label>
+                                <input type="file" name="image" id="image" class="form-control">
+                                @error('image')
+                                    <span class="text-danger">{{ $message }}</span>
+                                @enderror
+                                @if ($keyFeature->image)
+                                    <img src="{{ asset('storage/key_features/' . $keyFeature->image) }}"
+                                        alt="{{ $keyFeature->name }}" width="100" class="mt-2">
+                                @endif
+                            </div>
+                            <button type="submit" class="btn btn-primary">Update</button>
+                        </form>
+                    </div>
+                    <!-- /.card-body -->
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/key_features/index.blade.php
+++ b/resources/views/admin/key_features/index.blade.php
@@ -1,0 +1,55 @@
+@extends('admin.layouts.app')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header d-flex justify-content-between">
+                        <h3 class="card-title">Key Features</h3>
+                        <a href="{{ route('admin.key-features.create') }}" class="btn btn-primary">Create Key Feature</a>
+                    </div>
+                    <!-- /.card-header -->
+                    <div class="card-body">
+                        <table id="example1" class="table table-bordered table-striped">
+                            <thead>
+                                <tr>
+                                    <th>#</th>
+                                    <th>Image</th>
+                                    <th>Name</th>
+                                    <th>Description</th>
+                                    <th>Action</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach ($keyFeatures as $keyFeature)
+                                    <tr>
+                                        <td>{{ $loop->iteration }}</td>
+                                        <td>
+                                            <img src="{{ asset('storage/key_features/' . $keyFeature->image) }}"
+                                                alt="{{ $keyFeature->name }}" width="100">
+                                        </td>
+                                        <td>{{ $keyFeature->name }}</td>
+                                        <td>{{ $keyFeature->description }}</td>
+                                        <td>
+                                            <a href="{{ route('admin.key-features.edit', $keyFeature->id) }}"
+                                                class="btn btn-primary">Edit</a>
+                                            <form action="{{ route('admin.key-features.destroy', $keyFeature->id) }}"
+                                                method="POST" class="d-inline">
+                                                @csrf
+                                                @method('DELETE')
+                                                <button type="submit" class="btn btn-danger"
+                                                    onclick="return confirm('Are you sure?')">Delete</button>
+                                            </form>
+                                        </td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                    <!-- /.card-body -->
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/key_features/show.blade.php
+++ b/resources/views/admin/key_features/show.blade.php
@@ -1,0 +1,48 @@
+@extends('admin.layouts.app')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title">Key Feature Details</h3>
+                    </div>
+                    <!-- /.card-header -->
+                    <div class="card-body">
+                        <table class="table table-bordered">
+                            <tbody>
+                                <tr>
+                                    <th>ID</th>
+                                    <td>{{ $keyFeature->id }}</td>
+                                </tr>
+                                <tr>
+                                    <th>Name</th>
+                                    <td>{{ $keyFeature->name }}</td>
+                                </tr>
+                                <tr>
+                                    <th>Description</th>
+                                    <td>{{ $keyFeature->description }}</td>
+                                </tr>
+                                <tr>
+                                    <th>Image</th>
+                                    <td>
+                                        @if ($keyFeature->image)
+                                            <img src="{{ asset('storage/key_features/' . $keyFeature->image) }}"
+                                                alt="{{ $keyFeature->name }}" width="200">
+                                        @endif
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <!-- /.card-body -->
+                    <div class="card-footer">
+                        <a href="{{ route('admin.key-features.edit', $keyFeature->id) }}" class="btn btn-primary">Edit</a>
+                        <a href="{{ route('admin.key-features.index') }}" class="btn btn-secondary">Back</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/layouts/app.blade.php
+++ b/resources/views/admin/layouts/app.blade.php
@@ -27,6 +27,8 @@
                     <a href="{{ route('admin.service-types.index') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Service Types</a>
                     <a href="{{ route('admin.price-plans.index') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Price Plans</a>
                     <a href="{{ route('admin.softwares.index') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Softwares</a>
+                    <a href="{{ route('admin.technologies.index') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Technologies</a>
+                    <a href="{{ route('admin.key-features.index') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Key Features</a>
                     <a href="{{ route('admin.articles.index') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Articles</a>
                     <a href="{{ route('admin.trusted-companies.index') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Trusted Companies</a>
                     <a href="{{ route('admin.clients.index') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Clients</a>

--- a/resources/views/admin/technologies/create.blade.php
+++ b/resources/views/admin/technologies/create.blade.php
@@ -1,0 +1,45 @@
+@extends('admin.layouts.app')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title">Create Technology</h3>
+                    </div>
+                    <!-- /.card-header -->
+                    <div class="card-body">
+                        <form action="{{ route('admin.technologies.store') }}" method="POST" enctype="multipart/form-data">
+                            @csrf
+                            <div class="form-group">
+                                <label for="name">Name</label>
+                                <input type="text" name="name" id="name" class="form-control"
+                                    value="{{ old('name') }}">
+                                @error('name')
+                                    <span class="text-danger">{{ $message }}</span>
+                                @enderror
+                            </div>
+                            <div class="form-group">
+                                <label for="description">Description</label>
+                                <textarea name="description" id="description" class="form-control">{{ old('description') }}</textarea>
+                                @error('description')
+                                    <span class="text-danger">{{ $message }}</span>
+                                @enderror
+                            </div>
+                            <div class="form-group">
+                                <label for="image">Image</label>
+                                <input type="file" name="image" id="image" class="form-control">
+                                @error('image')
+                                    <span class="text-danger">{{ $message }}</span>
+                                @enderror
+                            </div>
+                            <button type="submit" class="btn btn-primary">Create</button>
+                        </form>
+                    </div>
+                    <!-- /.card-body -->
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/technologies/edit.blade.php
+++ b/resources/views/admin/technologies/edit.blade.php
@@ -1,0 +1,51 @@
+@extends('admin.layouts.app')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title">Edit Technology</h3>
+                    </div>
+                    <!-- /.card-header -->
+                    <div class="card-body">
+                        <form action="{{ route('admin.technologies.update', $technology->id) }}" method="POST"
+                            enctype="multipart/form-data">
+                            @csrf
+                            @method('PUT')
+                            <div class="form-group">
+                                <label for="name">Name</label>
+                                <input type="text" name="name" id="name" class="form-control"
+                                    value="{{ old('name', $technology->name) }}">
+                                @error('name')
+                                    <span class="text-danger">{{ $message }}</span>
+                                @enderror
+                            </div>
+                            <div class="form-group">
+                                <label for="description">Description</label>
+                                <textarea name="description" id="description" class="form-control">{{ old('description', $technology->description) }}</textarea>
+                                @error('description')
+                                    <span class="text-danger">{{ $message }}</span>
+                                @enderror
+                            </div>
+                            <div class="form-group">
+                                <label for="image">Image</label>
+                                <input type="file" name="image" id="image" class="form-control">
+                                @error('image')
+                                    <span class="text-danger">{{ $message }}</span>
+                                @enderror
+                                @if ($technology->image)
+                                    <img src="{{ asset('storage/technologies/' . $technology->image) }}"
+                                        alt="{{ $technology->name }}" width="100" class="mt-2">
+                                @endif
+                            </div>
+                            <button type="submit" class="btn btn-primary">Update</button>
+                        </form>
+                    </div>
+                    <!-- /.card-body -->
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/technologies/index.blade.php
+++ b/resources/views/admin/technologies/index.blade.php
@@ -1,0 +1,55 @@
+@extends('admin.layouts.app')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header d-flex justify-content-between">
+                        <h3 class="card-title">Technologies</h3>
+                        <a href="{{ route('admin.technologies.create') }}" class="btn btn-primary">Create Technology</a>
+                    </div>
+                    <!-- /.card-header -->
+                    <div class="card-body">
+                        <table id="example1" class="table table-bordered table-striped">
+                            <thead>
+                                <tr>
+                                    <th>#</th>
+                                    <th>Image</th>
+                                    <th>Name</th>
+                                    <th>Description</th>
+                                    <th>Action</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach ($technologies as $technology)
+                                    <tr>
+                                        <td>{{ $loop->iteration }}</td>
+                                        <td>
+                                            <img src="{{ asset('storage/technologies/' . $technology->image) }}"
+                                                alt="{{ $technology->name }}" width="100">
+                                        </td>
+                                        <td>{{ $technology->name }}</td>
+                                        <td>{{ $technology->description }}</td>
+                                        <td>
+                                            <a href="{{ route('admin.technologies.edit', $technology->id) }}"
+                                                class="btn btn-primary">Edit</a>
+                                            <form action="{{ route('admin.technologies.destroy', $technology->id) }}"
+                                                method="POST" class="d-inline">
+                                                @csrf
+                                                @method('DELETE')
+                                                <button type="submit" class="btn btn-danger"
+                                                    onclick="return confirm('Are you sure?')">Delete</button>
+                                            </form>
+                                        </td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                    <!-- /.card-body -->
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/technologies/show.blade.php
+++ b/resources/views/admin/technologies/show.blade.php
@@ -1,0 +1,48 @@
+@extends('admin.layouts.app')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title">Technology Details</h3>
+                    </div>
+                    <!-- /.card-header -->
+                    <div class="card-body">
+                        <table class="table table-bordered">
+                            <tbody>
+                                <tr>
+                                    <th>ID</th>
+                                    <td>{{ $technology->id }}</td>
+                                </tr>
+                                <tr>
+                                    <th>Name</th>
+                                    <td>{{ $technology->name }}</td>
+                                </tr>
+                                <tr>
+                                    <th>Description</th>
+                                    <td>{{ $technology->description }}</td>
+                                </tr>
+                                <tr>
+                                    <th>Image</th>
+                                    <td>
+                                        @if ($technology->image)
+                                            <img src="{{ asset('storage/technologies/' . $technology->image) }}"
+                                                alt="{{ $technology->name }}" width="200">
+                                        @endif
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <!-- /.card-body -->
+                    <div class="card-footer">
+                        <a href="{{ route('admin.technologies.edit', $technology->id) }}" class="btn btn-primary">Edit</a>
+                        <a href="{{ route('admin.technologies.index') }}" class="btn btn-secondary">Back</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/frontend/services/show.blade.php
+++ b/resources/views/frontend/services/show.blade.php
@@ -1,183 +1,94 @@
 @extends('frontend.layouts.app')
-@section('title', 'Article - ' . $article->title)
+@section('title', 'Service - ' . $service->name)
 
 @section('content')
-
     <div class="container ">
-
-        <h2 class="w-full lg:w-8/12 heading-text-regular-large  text-secondary-950 mt-20">{{ $article->title }}</h2>
-        <div class="mt-7 inline-flex items-center flex-wrap gap-4 ">
-            <div class="hero-badge-desktop">Digital Marketing</div>
-            <div class="hero-badge-desktop">Digital Marketing</div>
-            <div class="hero-badge-desktop">Digital Strategy</div>
-            <div class="hero-badge-desktop">Email Campaigns</div>
-            <div class="hero-badge-desktop">Boost Engagement </div>
-            <div class="hero-badge-desktop">Increase Conversions</div>
-        </div>
+        <h2 class="w-full lg:w-8/12 heading-text-regular-large text-secondary-950 mt-20">{{ $service->name }}</h2>
 
         <div class="flex flex-col mx-auto items-center justify-center mt-20">
             <div class="w-8/12 ">
-                <img class="rounded-lg m-auto w-full h-auto object-cover" src="{{ asset('upload/articles/card img.png') }}" alt="">
-                <p class=" text-secondary-600 sub-title-medium-regular mt-14"> In today’s digital world, email marketing remains one of the most powerful tools for businesses to engage their audience, build relationships, and drive conversions. Whether
-                    you're a startup or an established enterprise, an effective email campaign can enhance brand visibility, increase sales, and improve customer retention. </p>
-                <p class="text-secondary-800 sub-title-medium-regular mt-8"> In this article, we will explore proven email campaign strategies to help you maximize your marketing efforts and achieve your business goals. </p>
+                <img class="rounded-lg m-auto w-full h-auto object-cover" src="{{ asset('storage/services/' . $service->image) }}" alt="{{ $service->name }}">
             </div>
         </div>
 
-        {{-- card section  --}}
+        {{-- Key Features Section --}}
+        <div class="my-20" x-data="{ activeTab: 0 }">
+            <h2 class="heading-text-regular-medium text-center text-secondary-900 mb-8">Key Features</h2>
+            <div class="flex justify-center mb-8">
+                @foreach ($service->keyFeatures as $key => $keyFeature)
+                    <button @click="activeTab = {{ $key }}"
+                        :class="{ 'bg-primary-500 text-white': activeTab === {{ $key }}, 'bg-white text-secondary-900': activeTab !== {{ $key }} }"
+                        class="px-4 py-2 border rounded-md">{{ $keyFeature->name }}</button>
+                @endforeach
+            </div>
+            @foreach ($service->keyFeatures as $key => $keyFeature)
+                <div x-show="activeTab === {{ $key }}" class="text-center">
+                    <p>{{ $keyFeature->description }}</p>
+                </div>
+            @endforeach
+        </div>
+
+        {{-- Technologies Section --}}
         <div class="my-20">
-            <div class="card">
-                <h1 class="heading-text-regular-medium  text-secondary-950 tracking-[0.88px]">Understanding
-                    the Importance of Email Marketing</h1>
-                <hr class="h-px bg-secondary-400 border-none">
-                <div class="flex flex-col justify-center gap-4 text-secondary-800">
-                    <p class="label-text-regular-large ">Email marketing is a cost-effective and direct
-                        way to communicate with potential and existing customers. Unlike social media, where algorithms
-                        control visibility, email allows businesses to directly reach their audience’s inbox.</p>
-
-                    <h5 class="sub-title-medium-bold ">Key Benefits of Email Marketing:</h5>
-                    <ul class="list-disc ml-6 sub-title-medium-regular">
-                        <li>High ROI – Email campaigns generate an average return of $42 for every $1 spent (Source: DMA).</li>
-                        <li>Personalized Engagement – Tailored messages improve customer relationships.</li>
-                        <li>Automation & Efficiency – Saves time with scheduled and triggered emails.</li>
-                        <li>Measurable Performance – Track open rates, click-through rates, and conversions.</li>
-                    </ul>
-                </div>
-            </div>
-
-            <div class="card">
-                <h1 class="heading-text-regular-medium  text-secondary-950 tracking-[0.88px]">Defining Your Email Campaign Goals</h1>
-                <hr class="h-px bg-secondary-400 border-none">
-                <div class="flex flex-col justify-center gap-4 text-secondary-800">
-                    <p class="label-text-regular-large ">Email marketing is a cost-effective and direct
-                        way to communicate with potential and existing customers. Unlike social media, where algorithms
-                        control visibility, email allows businesses to directly reach their audience’s inbox.</p>
-
-                    <h5 class="sub-title-medium-bold ">Key Benefits of Email Marketing:</h5>
-                    <ul class="list-disc ml-6 sub-title-medium-regular">
-                        <li>High ROI – Email campaigns generate an average return of $42 for every $1 spent (Source: DMA).</li>
-                        <li>Personalized Engagement – Tailored messages improve customer relationships.</li>
-                        <li>Automation & Efficiency – Saves time with scheduled and triggered emails.</li>
-                        <li>Measurable Performance – Track open rates, click-through rates, and conversions.</li>
-                    </ul>
-                </div>
-            </div>
-
-            <div class="flex flex-col justify-center w-full md:w-10/12 xl:w-6/12 mx-auto mt-14">
-                <h1 class="heading-text-bold-large">Analyzing & Optimizing Your Campaign Performance</h1>
-                <p class="mt-4 sub-title-medium-regular text-secondary-600">To improve your email campaigns, track key
-                    performance metrics and adjust strategies accordingly.
-
-                </p>
-                <div class=" mt-8">
-                    <h3 class=" sub-title-medium-regular text-secondary-600 ">Key Email Metrics to Monitor:</h3>
-                    <ul class="sub-title-medium-regular text-secondary-600 ">
-                        <li> Open Rate – Percentage of recipients who open your email.</li>
-                        <li>Click-Through Rate (CTR) – Percentage of recipients who click a link.</li>
-                        <li>Conversion Rate – Percentage of users who complete a desired action.</li>
-                        <li>Bounce Rate – Percentage of undelivered emails due to invalid addresses.</li>
-                    </ul>
-                </div>
-
-                <div class="mt-4">
-                    <p class=" sub-title-medium-regular text-secondary-600"> Pro Tip: A/B test different subject lines, CTAs, and email designs to identify what works best for your audience.</p>
-                </div>
-
-            </div>
-
-            <div class="flex flex-col justify-center  w-full md:w-10/12 xl:w-6/12 mx-auto mt-14">
-                <h1 class="heading-text-bold-large">Conclusion: Elevate Your Email Marketing Strategy</h1>
-                <p class="mt-4 sub-title-medium-regular text-secondary-600">A well-planned email campaign can significantly
-                    boost customer engagement, increase sales, and build long-term relationships. By following these
-                    strategies—building a strong email list, crafting compelling content, optimizing timing, leveraging
-                    automation, and analyzing performance—you can create highly effective email marketing campaigns that drive
-                    results.
-                </p>
-                <p class=" mt-5 sub-title-medium-regular text-secondary-600">
-                    Ready to enhance your email marketing strategy? Start applying these insights today and watch your engagement soar!
-                </p>
-            </div>
-        </div>
-
-
-
-
-        {{-- Article Slider Section start ================================================== --}}
-        <div class="slider-container mt-20 xl:mb-20 overflow-hidden">
-            <div>
-                <h1 class="heading-text-regular-medium text-center text-secondary-900">Other Articles</h1>
-                <div class="flex justify-between my-8 gap-5">
-                    <p class="body-text-regular-medium text-secondary-800 w-full  md:w-1/2"> Stay informed with our expert insights! Explore articles on the latest trends, tips, and strategies in web design, digital marketing, and more. </p>
-                    <div class="button-group border-secondary-600">
-                        <button class="prev-btn button-label w-9 px-3 py-2 border-secondary-600 text-secondary-600"> <i class="w-5 h-5 fa-solid fa-circle-chevron-left"></i> </button>
-                        <button class="next-btn button-label w-9 px-3 py-2 border-secondary-600 text-secondary-600"> <i class="w-5 h-5 fa-solid fa-circle-chevron-right"></i> </button>
-                    </div>
-                </div>
-            </div>
-
-            <div class="articles-container flex gap-10">
-                @foreach ($articles as $item)
-                    <div class="article-item w-1/3">
-                        <img class=" max-h-72 w-full object-cover rounded-xl self-start" src="{{ asset('upload/articles/card img.png') }}" alt="Article Image" />
-                        <div class="mt-4">
-                            <button class="px-4 py-2   border rounded-full border-secondary-200 label-text-regular-small text-secondary-800"> {{ $item->article_category->title }} </button>
-                            <h2 class="title-text-bold-medium text-secondary-950 pt-2"> {{ $item->title }} </h2>
-                            <p class="body-text-regular-medium text-secondary-600 pt-1"> {{ $item->short_text }} </p>
+            <h2 class="heading-text-regular-medium text-center text-secondary-900 mb-8">Technologies We Use</h2>
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+                @foreach ($service->technologies as $technology)
+                    <div class="card">
+                        <img class="w-full h-48 object-cover rounded-t-lg" src="{{ asset('storage/technologies/' . $technology->image) }}" alt="{{ $technology->name }}">
+                        <div class="p-4">
+                            <h3 class="title-text-bold-medium text-secondary-950">{{ $technology->name }}</h3>
+                            <p class="body-text-regular-medium text-secondary-600 mt-2">{{ $technology->description }}</p>
                         </div>
-
-                        <a href="{{ route('articles.show', $item->slug) }}" class="inline-block px-3 py-2 rounded-sm border border-secondary-800 label-text-bold-small text-secondary-800 mt-4"> Read more </a>
                     </div>
                 @endforeach
             </div>
         </div>
 
+        {{-- Service Plans Section --}}
+        <div class="my-20" x-data="{ activeTab: 0 }">
+            <h2 class="heading-text-regular-medium text-center text-secondary-900 mb-8">Service Plans</h2>
+            <div class="flex justify-center mb-8">
+                @foreach ($service->serviceTypes as $key => $serviceType)
+                    <button @click="activeTab = {{ $key }}"
+                        :class="{ 'border-b-2 border-primary-500 text-primary-500': activeTab === {{ $key }}, 'text-secondary-600': activeTab !== {{ $key }} }"
+                        class="px-4 py-2 focus:outline-none">{{ $serviceType->name }}</button>
+                @endforeach
+            </div>
+
+            @foreach ($service->serviceTypes as $key => $serviceType)
+                <div x-show="activeTab === {{ $key }}" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+                    @foreach ($serviceType->pricePlans as $plan)
+                        <div class="border rounded-lg p-6 flex flex-col @if($plan->name === 'Advanced') border-primary-500 @endif">
+                            <div class="flex justify-between items-center">
+                                <h3 class="title-text-bold-medium text-secondary-950">{{ $plan->name }}</h3>
+                                @if($plan->name === 'Advanced')
+                                    <span class="bg-red-500 text-white text-xs font-bold px-2 py-1 rounded">Popular</span>
+                                @endif
+                            </div>
+                            <div class="my-4">
+                                <span class="heading-text-bold-large text-secondary-950">${{ $plan->price }}</span>
+                                <span class="body-text-regular-medium text-secondary-600">/Per {{ $plan->type }}</span>
+                            </div>
+                            <p class="body-text-regular-medium text-secondary-600 mb-4">Why should you take this</p>
+                            <ul class="space-y-2">
+                                @foreach ($plan->features as $feature)
+                                    <li class="flex items-center">
+                                        <svg class="w-5 h-5 text-green-500 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                                        <span class="body-text-regular-medium text-secondary-600">{{ $feature }}</span>
+                                    </li>
+                                @endforeach
+                            </ul>
+                            <div class="mt-auto pt-6">
+                                @if($plan->name === 'Advanced')
+                                    <a href="#" class="btn btn-outline-primary w-full">Let's discuss</a>
+                                @else
+                                    <a href="#" class="btn btn-primary w-full">Add to cart</a>
+                                @endif
+                            </div>
+                        </div>
+                    @endforeach
+                </div>
+            @endforeach
+        </div>
     </div>
-
-@endsection
-
-@section('extra-js')
-    <script>
-        $(document).ready(function() {
-            let total = $('.article-item').length;
-            let visible = 3;
-
-            function updateVisible() {
-                if (window.innerWidth <= 640) {
-                    visible = 1;
-                } else if (window.innerWidth <= 1024) {
-                    visible = 2;
-                } else {
-                    visible = 3;
-                }
-            }
-
-            updateVisible();
-
-            $('.articles-container').slick({
-                slidesToShow: visible,
-                slidesToScroll: 1,
-                autoplay: true,
-                autoplaySpeed: 3000,
-                prevArrow: '.prev-btn',
-                nextArrow: '.next-btn',
-                responsive: [{
-                        breakpoint: 1024,
-                        settings: {
-                            slidesToShow: 2
-                        }
-                    },
-                    {
-                        breakpoint: 640,
-                        settings: {
-                            slidesToShow: 1
-                        }
-                    }
-                ]
-            });
-            $(window).resize(function() {
-                updateVisible();
-                $('.articles-container').slick('slickSetOption', 'slidesToShow', visible, true);
-            });
-        });
-    </script>
 @endsection

--- a/resources/views/frontend/softwares/show.blade.php
+++ b/resources/views/frontend/softwares/show.blade.php
@@ -1,183 +1,94 @@
 @extends('frontend.layouts.app')
-@section('title', 'Article - ' . $article->title)
+@section('title', 'Software - ' . $software->name)
 
 @section('content')
-
     <div class="container ">
-
-        <h2 class="w-full lg:w-8/12 heading-text-regular-large  text-secondary-950 mt-20">{{ $article->title }}</h2>
-        <div class="mt-7 inline-flex items-center flex-wrap gap-4 ">
-            <div class="hero-badge-desktop">Digital Marketing</div>
-            <div class="hero-badge-desktop">Digital Marketing</div>
-            <div class="hero-badge-desktop">Digital Strategy</div>
-            <div class="hero-badge-desktop">Email Campaigns</div>
-            <div class="hero-badge-desktop">Boost Engagement </div>
-            <div class="hero-badge-desktop">Increase Conversions</div>
-        </div>
+        <h2 class="w-full lg:w-8/12 heading-text-regular-large text-secondary-950 mt-20">{{ $software->name }}</h2>
 
         <div class="flex flex-col mx-auto items-center justify-center mt-20">
             <div class="w-8/12 ">
-                <img class="rounded-lg m-auto w-full h-auto object-cover" src="{{ asset('upload/articles/card img.png') }}" alt="">
-                <p class=" text-secondary-600 sub-title-medium-regular mt-14"> In today’s digital world, email marketing remains one of the most powerful tools for businesses to engage their audience, build relationships, and drive conversions. Whether
-                    you're a startup or an established enterprise, an effective email campaign can enhance brand visibility, increase sales, and improve customer retention. </p>
-                <p class="text-secondary-800 sub-title-medium-regular mt-8"> In this article, we will explore proven email campaign strategies to help you maximize your marketing efforts and achieve your business goals. </p>
+                <img class="rounded-lg m-auto w-full h-auto object-cover" src="{{ asset('storage/softwares/' . $software->image) }}" alt="{{ $software->name }}">
             </div>
         </div>
 
-        {{-- card section  --}}
+        {{-- Key Features Section --}}
+        <div class="my-20" x-data="{ activeTab: 0 }">
+            <h2 class="heading-text-regular-medium text-center text-secondary-900 mb-8">Key Features</h2>
+            <div class="flex justify-center mb-8">
+                @foreach ($software->keyFeatures as $key => $keyFeature)
+                    <button @click="activeTab = {{ $key }}"
+                        :class="{ 'bg-primary-500 text-white': activeTab === {{ $key }}, 'bg-white text-secondary-900': activeTab !== {{ $key }} }"
+                        class="px-4 py-2 border rounded-md">{{ $keyFeature->name }}</button>
+                @endforeach
+            </div>
+            @foreach ($software->keyFeatures as $key => $keyFeature)
+                <div x-show="activeTab === {{ $key }}" class="text-center">
+                    <p>{{ $keyFeature->description }}</p>
+                </div>
+            @endforeach
+        </div>
+
+        {{-- Technologies Section --}}
         <div class="my-20">
-            <div class="card">
-                <h1 class="heading-text-regular-medium  text-secondary-950 tracking-[0.88px]">Understanding
-                    the Importance of Email Marketing</h1>
-                <hr class="h-px bg-secondary-400 border-none">
-                <div class="flex flex-col justify-center gap-4 text-secondary-800">
-                    <p class="label-text-regular-large ">Email marketing is a cost-effective and direct
-                        way to communicate with potential and existing customers. Unlike social media, where algorithms
-                        control visibility, email allows businesses to directly reach their audience’s inbox.</p>
-
-                    <h5 class="sub-title-medium-bold ">Key Benefits of Email Marketing:</h5>
-                    <ul class="list-disc ml-6 sub-title-medium-regular">
-                        <li>High ROI – Email campaigns generate an average return of $42 for every $1 spent (Source: DMA).</li>
-                        <li>Personalized Engagement – Tailored messages improve customer relationships.</li>
-                        <li>Automation & Efficiency – Saves time with scheduled and triggered emails.</li>
-                        <li>Measurable Performance – Track open rates, click-through rates, and conversions.</li>
-                    </ul>
-                </div>
-            </div>
-
-            <div class="card">
-                <h1 class="heading-text-regular-medium  text-secondary-950 tracking-[0.88px]">Defining Your Email Campaign Goals</h1>
-                <hr class="h-px bg-secondary-400 border-none">
-                <div class="flex flex-col justify-center gap-4 text-secondary-800">
-                    <p class="label-text-regular-large ">Email marketing is a cost-effective and direct
-                        way to communicate with potential and existing customers. Unlike social media, where algorithms
-                        control visibility, email allows businesses to directly reach their audience’s inbox.</p>
-
-                    <h5 class="sub-title-medium-bold ">Key Benefits of Email Marketing:</h5>
-                    <ul class="list-disc ml-6 sub-title-medium-regular">
-                        <li>High ROI – Email campaigns generate an average return of $42 for every $1 spent (Source: DMA).</li>
-                        <li>Personalized Engagement – Tailored messages improve customer relationships.</li>
-                        <li>Automation & Efficiency – Saves time with scheduled and triggered emails.</li>
-                        <li>Measurable Performance – Track open rates, click-through rates, and conversions.</li>
-                    </ul>
-                </div>
-            </div>
-
-            <div class="flex flex-col justify-center w-full md:w-10/12 xl:w-6/12 mx-auto mt-14">
-                <h1 class="heading-text-bold-large">Analyzing & Optimizing Your Campaign Performance</h1>
-                <p class="mt-4 sub-title-medium-regular text-secondary-600">To improve your email campaigns, track key
-                    performance metrics and adjust strategies accordingly.
-
-                </p>
-                <div class=" mt-8">
-                    <h3 class=" sub-title-medium-regular text-secondary-600 ">Key Email Metrics to Monitor:</h3>
-                    <ul class="sub-title-medium-regular text-secondary-600 ">
-                        <li> Open Rate – Percentage of recipients who open your email.</li>
-                        <li>Click-Through Rate (CTR) – Percentage of recipients who click a link.</li>
-                        <li>Conversion Rate – Percentage of users who complete a desired action.</li>
-                        <li>Bounce Rate – Percentage of undelivered emails due to invalid addresses.</li>
-                    </ul>
-                </div>
-
-                <div class="mt-4">
-                    <p class=" sub-title-medium-regular text-secondary-600"> Pro Tip: A/B test different subject lines, CTAs, and email designs to identify what works best for your audience.</p>
-                </div>
-
-            </div>
-
-            <div class="flex flex-col justify-center  w-full md:w-10/12 xl:w-6/12 mx-auto mt-14">
-                <h1 class="heading-text-bold-large">Conclusion: Elevate Your Email Marketing Strategy</h1>
-                <p class="mt-4 sub-title-medium-regular text-secondary-600">A well-planned email campaign can significantly
-                    boost customer engagement, increase sales, and build long-term relationships. By following these
-                    strategies—building a strong email list, crafting compelling content, optimizing timing, leveraging
-                    automation, and analyzing performance—you can create highly effective email marketing campaigns that drive
-                    results.
-                </p>
-                <p class=" mt-5 sub-title-medium-regular text-secondary-600">
-                    Ready to enhance your email marketing strategy? Start applying these insights today and watch your engagement soar!
-                </p>
-            </div>
-        </div>
-
-
-
-
-        {{-- Article Slider Section start ================================================== --}}
-        <div class="slider-container mt-20 xl:mb-20 overflow-hidden">
-            <div>
-                <h1 class="heading-text-regular-medium text-center text-secondary-900">Other Articles</h1>
-                <div class="flex justify-between my-8 gap-5">
-                    <p class="body-text-regular-medium text-secondary-800 w-full  md:w-1/2"> Stay informed with our expert insights! Explore articles on the latest trends, tips, and strategies in web design, digital marketing, and more. </p>
-                    <div class="button-group border-secondary-600">
-                        <button class="prev-btn button-label w-9 px-3 py-2 border-secondary-600 text-secondary-600"> <i class="w-5 h-5 fa-solid fa-circle-chevron-left"></i> </button>
-                        <button class="next-btn button-label w-9 px-3 py-2 border-secondary-600 text-secondary-600"> <i class="w-5 h-5 fa-solid fa-circle-chevron-right"></i> </button>
-                    </div>
-                </div>
-            </div>
-
-            <div class="articles-container flex gap-10">
-                @foreach ($articles as $item)
-                    <div class="article-item w-1/3">
-                        <img class=" max-h-72 w-full object-cover rounded-xl self-start" src="{{ asset('upload/articles/card img.png') }}" alt="Article Image" />
-                        <div class="mt-4">
-                            <button class="px-4 py-2   border rounded-full border-secondary-200 label-text-regular-small text-secondary-800"> {{ $item->article_category->title }} </button>
-                            <h2 class="title-text-bold-medium text-secondary-950 pt-2"> {{ $item->title }} </h2>
-                            <p class="body-text-regular-medium text-secondary-600 pt-1"> {{ $item->short_text }} </p>
+            <h2 class="heading-text-regular-medium text-center text-secondary-900 mb-8">Technologies We Use</h2>
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+                @foreach ($software->technologies as $technology)
+                    <div class="card">
+                        <img class="w-full h-48 object-cover rounded-t-lg" src="{{ asset('storage/technologies/' . $technology->image) }}" alt="{{ $technology->name }}">
+                        <div class="p-4">
+                            <h3 class="title-text-bold-medium text-secondary-950">{{ $technology->name }}</h3>
+                            <p class="body-text-regular-medium text-secondary-600 mt-2">{{ $technology->description }}</p>
                         </div>
-
-                        <a href="{{ route('articles.show', $item->slug) }}" class="inline-block px-3 py-2 rounded-sm border border-secondary-800 label-text-bold-small text-secondary-800 mt-4"> Read more </a>
                     </div>
                 @endforeach
             </div>
         </div>
 
+        {{-- Software Plans Section --}}
+        <div class="my-20" x-data="{ activeTab: 0 }">
+            <h2 class="heading-text-regular-medium text-center text-secondary-900 mb-8">Software Plans</h2>
+            <div class="flex justify-center mb-8">
+                @foreach ($groupedPricePlans as $type => $plans)
+                    <button @click="activeTab = {{ $loop->index }}"
+                        :class="{ 'border-b-2 border-primary-500 text-primary-500': activeTab === {{ $loop->index }}, 'text-secondary-600': activeTab !== {{ $loop->index }} }"
+                        class="px-4 py-2 focus:outline-none">{{ ucfirst($type) }}</button>
+                @endforeach
+            </div>
+
+            @foreach ($groupedPricePlans as $type => $plans)
+                <div x-show="activeTab === {{ $loop->index }}" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+                    @foreach ($plans as $plan)
+                        <div class="border rounded-lg p-6 flex flex-col @if($plan->name === 'Advanced') border-primary-500 @endif">
+                            <div class="flex justify-between items-center">
+                                <h3 class="title-text-bold-medium text-secondary-950">{{ $plan->name }}</h3>
+                                @if($plan->name === 'Advanced')
+                                    <span class="bg-red-500 text-white text-xs font-bold px-2 py-1 rounded">Popular</span>
+                                @endif
+                            </div>
+                            <div class="my-4">
+                                <span class="heading-text-bold-large text-secondary-950">${{ $plan->price }}</span>
+                                <span class="body-text-regular-medium text-secondary-600">/Per {{ $plan->type }}</span>
+                            </div>
+                            <p class="body-text-regular-medium text-secondary-600 mb-4">Why should you take this</p>
+                            <ul class="space-y-2">
+                                @foreach ($plan->features as $feature)
+                                    <li class="flex items-center">
+                                        <svg class="w-5 h-5 text-green-500 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                                        <span class="body-text-regular-medium text-secondary-600">{{ $feature }}</span>
+                                    </li>
+                                @endforeach
+                            </ul>
+                            <div class="mt-auto pt-6">
+                                @if($plan->name === 'Advanced')
+                                    <a href="#" class="btn btn-outline-primary w-full">Let's discuss</a>
+                                @else
+                                    <a href="#" class="btn btn-primary w-full">Add to cart</a>
+                                @endif
+                            </div>
+                        </div>
+                    @endforeach
+                </div>
+            @endforeach
+        </div>
     </div>
-
-@endsection
-
-@section('extra-js')
-    <script>
-        $(document).ready(function() {
-            let total = $('.article-item').length;
-            let visible = 3;
-
-            function updateVisible() {
-                if (window.innerWidth <= 640) {
-                    visible = 1;
-                } else if (window.innerWidth <= 1024) {
-                    visible = 2;
-                } else {
-                    visible = 3;
-                }
-            }
-
-            updateVisible();
-
-            $('.articles-container').slick({
-                slidesToShow: visible,
-                slidesToScroll: 1,
-                autoplay: true,
-                autoplaySpeed: 3000,
-                prevArrow: '.prev-btn',
-                nextArrow: '.next-btn',
-                responsive: [{
-                        breakpoint: 1024,
-                        settings: {
-                            slidesToShow: 2
-                        }
-                    },
-                    {
-                        breakpoint: 640,
-                        settings: {
-                            slidesToShow: 1
-                        }
-                    }
-                ]
-            });
-            $(window).resize(function() {
-                updateVisible();
-                $('.articles-container').slick('slickSetOption', 'slidesToShow', visible, true);
-            });
-        });
-    </script>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,8 @@ use App\Http\Controllers\Admin\SoftwareController;
 use App\Http\Controllers\Admin\SoftwareCategoryController;
 use App\Http\Controllers\Admin\VacancyCategoryController;
 use App\Http\Controllers\Admin\VacancyController;
+use App\Http\Controllers\Admin\TechnologyController;
+use App\Http\Controllers\Admin\KeyFeatureController;
 
 Route::get('/', function () {
     return view('welcome');
@@ -89,6 +91,8 @@ Route::name('admin.')->prefix('admin')->middleware(['auth'])->group(function () 
     Route::resource('softwares', SoftwareController::class);
     Route::resource('articles', ArticleController::class);
     Route::resource('vacancies', VacancyController::class);
+    Route::resource('technologies', TechnologyController::class);
+    Route::resource('key-features', KeyFeatureController::class);
     Route::resource('trusted-companies', \App\Http\Controllers\Admin\TrustedCompanyController::class);
     Route::resource('clients', \App\Http\Controllers\Admin\ClientController::class);
     Route::resource('faqs', \App\Http\Controllers\Admin\FaqController::class);


### PR DESCRIPTION
Adds the "Service Plans" and "Software Plans" sections to the frontend service and software detail pages.

- Updates the `ServiceFrontController` to eager-load `serviceTypes` and their nested `pricePlans`.
- Implements a tabbed interface for `serviceTypes` on the service detail page, displaying the associated price plans for each.
- Updates the `SoftwareFrontController` to eager-load `pricePlans` and group them by plan type.
- Implements a tabbed interface for `pricePlans` on the software detail page, with tabs corresponding to the plan type (e.g., Monthly, Yearly).
- Styles both sections to match the provided design specifications.