### PR TITLE
feat: Implement service price plan comparison page

### DIFF
--- a/app/Http/Controllers/Admin/FeatureController.php
+++ b/app/Http/Controllers/Admin/FeatureController.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Feature;
+use Illuminate\Http\Request;
+
+class FeatureController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        $features = Feature::all();
+        return view('admin.features.index', compact('features'));
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create()
+    {
+        return view('admin.features.create');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        $request->validate([
+            'name' => 'required|string|max:255',
+            'description' => 'nullable|string',
+        ]);
+
+        Feature::create($request->all());
+
+        return redirect()->route('admin.features.index')->with('success', 'Feature created successfully.');
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Feature $feature)
+    {
+        return view('admin.features.show', compact('feature'));
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(Feature $feature)
+    {
+        return view('admin.features.edit', compact('feature'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Feature $feature)
+    {
+        $request->validate([
+            'name' => 'required|string|max:255',
+            'description' => 'nullable|string',
+        ]);
+
+        $feature->update($request->all());
+
+        return redirect()->route('admin.features.index')->with('success', 'Feature updated successfully.');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Feature $feature)
+    {
+        $feature->delete();
+
+        return redirect()->route('admin.features.index')->with('success', 'Feature deleted successfully.');
+    }
+}

--- a/app/Http/Controllers/Admin/PricePlanController.php
+++ b/app/Http/Controllers/Admin/PricePlanController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Models\PricePlan;
 use App\Models\ServiceType;
+use App\Models\Feature;
 use Illuminate\Http\Request;
 
 class PricePlanController extends Controller
@@ -18,7 +19,8 @@ class PricePlanController extends Controller
     public function create()
     {
         $serviceTypes = ServiceType::all();
-        return view('admin.price-plans.create', compact('serviceTypes'));
+        $features = Feature::all();
+        return view('admin.price-plans.create', compact('serviceTypes', 'features'));
     }
 
     public function store(Request $request)
@@ -27,19 +29,27 @@ class PricePlanController extends Controller
             'name' => 'required|string|max:255',
             'price' => 'required_if:type,fixed|nullable|numeric',
             'type' => 'required|string|in:fixed,free,custom',
-            'features' => 'required|string',
             'planable_id' => 'required',
             'planable_type' => 'required|string',
         ]);
 
-        $data = $request->all();
-        $data['features'] = explode(',', $request->features);
+        $data = $request->except('features');
 
         if ($request->type === 'free' || $request->type === 'custom') {
             $data['price'] = null;
         }
 
-        PricePlan::create($data);
+        $pricePlan = PricePlan::create($data);
+
+        if ($request->has('features')) {
+            $features = [];
+            foreach ($request->features as $featureId => $featureData) {
+                if (isset($featureData['id'])) {
+                    $features[$featureId] = ['is_active' => $featureData['is_active']];
+                }
+            }
+            $pricePlan->features()->sync($features);
+        }
 
         return redirect()->route('admin.price-plans.index')->with('success', 'Price Plan created successfully.');
     }
@@ -47,7 +57,8 @@ class PricePlanController extends Controller
     public function edit(PricePlan $pricePlan)
     {
         $serviceTypes = ServiceType::all();
-        return view('admin.price-plans.edit', compact('pricePlan', 'serviceTypes'));
+        $features = Feature::all();
+        return view('admin.price-plans.edit', compact('pricePlan', 'serviceTypes', 'features'));
     }
 
     public function update(Request $request, PricePlan $pricePlan)
@@ -56,19 +67,29 @@ class PricePlanController extends Controller
             'name' => 'required|string|max:255',
             'price' => 'required_if:type,fixed|nullable|numeric',
             'type' => 'required|string|in:fixed,free,custom',
-            'features' => 'required|string',
             'planable_id' => 'required',
             'planable_type' => 'required|string',
         ]);
 
-        $data = $request->all();
-        $data['features'] = explode(',', $request->features);
+        $data = $request->except('features');
 
         if ($request->type === 'free' || $request->type === 'custom') {
             $data['price'] = null;
         }
 
         $pricePlan->update($data);
+
+        if ($request->has('features')) {
+            $features = [];
+            foreach ($request->features as $featureId => $featureData) {
+                if (isset($featureData['id'])) {
+                    $features[$featureId] = ['is_active' => $featureData['is_active']];
+                }
+            }
+            $pricePlan->features()->sync($features);
+        } else {
+            $pricePlan->features()->sync([]);
+        }
 
         return redirect()->route('admin.price-plans.index')->with('success', 'Price Plan updated successfully.');
     }

--- a/app/Http/Controllers/Frontend/PageController.php
+++ b/app/Http/Controllers/Frontend/PageController.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers\Frontend;
 use App\Http\Controllers\Controller;
 use App\Models\Team;
 use Illuminate\Http\Request;
+use App\Models\ServiceCategory;
+use App\Models\Feature;
 
 class PageController extends Controller
 {
@@ -78,5 +80,12 @@ class PageController extends Controller
     public function custom_software()
     {
         return view('frontend.custom-software');
+    }
+
+    public function service_plans()
+    {
+        $serviceCategories = ServiceCategory::with('services.serviceTypes.pricePlans.features')->get();
+        $features = Feature::all();
+        return view('frontend.service-plans', compact('serviceCategories', 'features'));
     }
 }

--- a/app/Models/Feature.php
+++ b/app/Models/Feature.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Feature extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'description',
+    ];
+
+    public function pricePlans()
+    {
+        return $this->belongsToMany(PricePlan::class)->withPivot('is_active');
+    }
+}

--- a/app/Models/PricePlan.php
+++ b/app/Models/PricePlan.php
@@ -15,15 +15,15 @@ class PricePlan extends Model
         'name',
         'price',
         'type',
-        'features',
-    ];
-
-    protected $casts = [
-        'features' => 'array',
     ];
 
     public function planable()
     {
         return $this->morphTo();
+    }
+
+    public function features()
+    {
+        return $this->belongsToMany(Feature::class)->withPivot('is_active');
     }
 }

--- a/database/migrations/2025_10_26_000000_create_features_table.php
+++ b/database/migrations/2025_10_26_000000_create_features_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('features', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('features');
+    }
+};

--- a/database/migrations/2025_10_26_000001_create_feature_price_plan_table.php
+++ b/database/migrations/2025_10_26_000001_create_feature_price_plan_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate.Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('feature_price_plan', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('feature_id')->constrained()->onDelete('cascade');
+            $table->foreignId('price_plan_id')->constrained()->onDelete('cascade');
+            $table->boolean('is_active')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('feature_price_plan');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -21,6 +21,7 @@ class DatabaseSeeder extends Seeder
             ClientSeeder::class,
             DesignationSeeder::class,
             FaqSeeder::class,
+            FeatureSeeder::class,
             PricePlanSeeder::class,
             ProjectCategorySeeder::class,
             ProjectSeeder::class,

--- a/database/seeders/FeatureSeeder.php
+++ b/database/seeders/FeatureSeeder.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Feature;
+use App\Models\PricePlan;
+use Illuminate\Database\Seeder;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+
+class FeatureSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $features = [
+            ['name' => 'Full Source Code'],
+            ['name' => 'Live Preview'],
+            ['name' => 'Support 24/7'],
+            ['name' => 'Product Review'],
+            ['name' => 'Product Demo'],
+        ];
+
+        foreach ($features as $feature) {
+            Feature::create($feature);
+        }
+
+        $pricePlans = PricePlan::all();
+        $features = Feature::all();
+
+        foreach ($pricePlans as $pricePlan) {
+            foreach ($features as $feature) {
+                $isActive = false;
+                if ($pricePlan->name === 'Basic') {
+                    $isActive = in_array($feature->name, ['Live Preview', 'Product Demo']);
+                } elseif ($pricePlan->name === 'Standard') {
+                    $isActive = in_array($feature->name, ['Live Preview', 'Support 24/7', 'Product Review', 'Product Demo']);
+                } elseif ($pricePlan->name === 'Advanced') {
+                    $isActive = true;
+                }
+
+                $pricePlan->features()->attach($feature->id, ['is_active' => $isActive]);
+            }
+        }
+    }
+}

--- a/resources/views/admin/features/create.blade.php
+++ b/resources/views/admin/features/create.blade.php
@@ -1,0 +1,29 @@
+@extends('admin.layouts.app')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title">Create Feature</h3>
+                    </div>
+                    <div class="card-body">
+                        <form action="{{ route('admin.features.store') }}" method="POST">
+                            @csrf
+                            <div class="form-group">
+                                <label for="name">Name</label>
+                                <input type="text" name="name" id="name" class="form-control" required>
+                            </div>
+                            <div class="form-group">
+                                <label for="description">Description</label>
+                                <textarea name="description" id="description" class="form-control" rows="3"></textarea>
+                            </div>
+                            <button type="submit" class="btn btn-primary">Create</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/features/edit.blade.php
+++ b/resources/views/admin/features/edit.blade.php
@@ -1,0 +1,31 @@
+@extends('admin.layouts.app')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title">Edit Feature</h3>
+                    </div>
+                    <div class="card-body">
+                        <form action="{{ route('admin.features.update', $feature->id) }}" method="POST">
+                            @csrf
+                            @method('PUT')
+                            <div class="form-group">
+                                <label for="name">Name</label>
+                                <input type="text" name="name" id="name" class="form-control"
+                                    value="{{ $feature->name }}" required>
+                            </div>
+                            <div class="form-group">
+                                <label for="description">Description</label>
+                                <textarea name="description" id="description" class="form-control" rows="3">{{ $feature->description }}</textarea>
+                            </div>
+                            <button type="submit" class="btn btn-primary">Update</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/features/index.blade.php
+++ b/resources/views/admin/features/index.blade.php
@@ -1,0 +1,48 @@
+@extends('admin.layouts.app')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header d-flex justify-content-between">
+                        <h3 class="card-title">Features</h3>
+                        <a href="{{ route('admin.features.create') }}" class="btn btn-primary">Create</a>
+                    </div>
+                    <div class="card-body">
+                        <table class="table table-bordered table-hover">
+                            <thead>
+                                <tr>
+                                    <th>#</th>
+                                    <th>Name</th>
+                                    <th>Description</th>
+                                    <th>Action</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach ($features as $feature)
+                                    <tr>
+                                        <td>{{ $loop->iteration }}</td>
+                                        <td>{{ $feature->name }}</td>
+                                        <td>{{ $feature->description }}</td>
+                                        <td>
+                                            <a href="{{ route('admin.features.edit', $feature->id) }}"
+                                                class="btn btn-primary">Edit</a>
+                                            <form action="{{ route('admin.features.destroy', $feature->id) }}"
+                                                method="POST" class="d-inline">
+                                                @csrf
+                                                @method('DELETE')
+                                                <button type="submit" class="btn btn-danger"
+                                                    onclick="return confirm('Are you sure you want to delete this item?');">Delete</button>
+                                            </form>
+                                        </td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/layouts/app.blade.php
+++ b/resources/views/admin/layouts/app.blade.php
@@ -29,6 +29,7 @@
                     <a href="{{ route('admin.softwares.index') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Softwares</a>
                     <a href="{{ route('admin.technologies.index') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Technologies</a>
                     <a href="{{ route('admin.key-features.index') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Key Features</a>
+                    <a href="{{ route('admin.features.index') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Features</a>
                     <a href="{{ route('admin.articles.index') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Articles</a>
                     <a href="{{ route('admin.trusted-companies.index') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Trusted Companies</a>
                     <a href="{{ route('admin.clients.index') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Clients</a>

--- a/resources/views/admin/price-plans/create.blade.php
+++ b/resources/views/admin/price-plans/create.blade.php
@@ -33,11 +33,23 @@
             @enderror
         </div>
         <div class="mb-4">
-            <label for="features" class="block text-gray-700">Features (comma-separated)</label>
-            <input type="text" name="features" id="features" class="w-full px-3 py-2 border rounded-md" value="{{ old('features') }}" required>
-            @error('features')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
+            <label class="block text-gray-700">Features</label>
+            @foreach ($features as $feature)
+                <div class="flex items-center">
+                    <input type="checkbox" name="features[{{ $feature->id }}][id]" value="{{ $feature->id }}" class="mr-2">
+                    <label>{{ $feature->name }}</label>
+                    <div class="ml-4">
+                        <label class="mr-2">
+                            <input type="radio" name="features[{{ $feature->id }}][is_active]" value="1" class="mr-1">
+                            Active
+                        </label>
+                        <label>
+                            <input type="radio" name="features[{{ $feature->id }}][is_active]" value="0" class="mr-1" checked>
+                            Inactive
+                        </label>
+                    </div>
+                </div>
+            @endforeach
         </div>
         <div class="mb-4">
             <label for="planable_type" class="block text-gray-700">Planable Type</label>

--- a/resources/views/admin/price-plans/edit.blade.php
+++ b/resources/views/admin/price-plans/edit.blade.php
@@ -34,11 +34,27 @@
             @enderror
         </div>
         <div class="mb-4">
-            <label for="features" class="block text-gray-700">Features (comma-separated)</label>
-            <input type="text" name="features" id="features" class="w-full px-3 py-2 border rounded-md" value="{{ old('features', implode(',', $pricePlan->features)) }}" required>
-            @error('features')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
+            <label class="block text-gray-700">Features</label>
+            @foreach ($features as $feature)
+                @php
+                    $planFeature = $pricePlan->features->firstWhere('id', $feature->id);
+                    $isActive = $planFeature ? $planFeature->pivot->is_active : false;
+                @endphp
+                <div class="flex items-center">
+                    <input type="checkbox" name="features[{{ $feature->id }}][id]" value="{{ $feature->id }}" class="mr-2" @if($planFeature) checked @endif>
+                    <label>{{ $feature->name }}</label>
+                    <div class="ml-4">
+                        <label class="mr-2">
+                            <input type="radio" name="features[{{ $feature->id }}][is_active]" value="1" class="mr-1" @if($isActive) checked @endif>
+                            Active
+                        </label>
+                        <label>
+                            <input type="radio" name="features[{{ $feature->id }}][is_active]" value="0" class="mr-1" @if(!$isActive) checked @endif>
+                            Inactive
+                        </label>
+                    </div>
+                </div>
+            @endforeach
         </div>
         <div class="mb-4">
             <label for="planable_type" class="block text-gray-700">Planable Type</label>

--- a/resources/views/frontend/service-plans.blade.php
+++ b/resources/views/frontend/service-plans.blade.php
@@ -1,0 +1,63 @@
+@extends('frontend.layouts.app')
+
+@section('content')
+    <div class="container mx-auto px-4 py-8">
+        <h1 class="text-3xl font-bold text-center mb-8">Service Plans</h1>
+
+        <div x-data="{ activeTab: {{ $serviceCategories->first()->id }} }">
+            <div class="flex justify-center mb-8">
+                @foreach ($serviceCategories as $category)
+                    <button @click="activeTab = {{ $category->id }}"
+                        :class="{ 'bg-blue-500 text-white': activeTab === {{ $category->id }}, 'bg-gray-200 text-gray-700': activeTab !== {{ $category->id }} }"
+                        class="px-4 py-2 rounded-md mr-4">{{ $category->title }}</button>
+                @endforeach
+            </div>
+
+            @foreach ($serviceCategories as $category)
+                <div x-show="activeTab === {{ $category->id }}">
+                    @foreach ($category->services as $service)
+                        @foreach ($service->serviceTypes as $serviceType)
+                            <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+                                @foreach ($serviceType->pricePlans as $plan)
+                                    <div class="bg-white rounded-lg shadow-md p-6">
+                                        <h2 class="text-xl font-bold mb-4">{{ $plan->name }}</h2>
+                                        <p class="text-3xl font-bold mb-4">${{ $plan->price }}</p>
+                                        <ul class="mb-4">
+                                            @foreach ($features as $feature)
+                                                <li class="flex items-center mb-2">
+                                                    @php
+                                                        $planFeature = $plan->features->firstWhere('id', $feature->id);
+                                                        $isActive = $planFeature ? $planFeature->pivot->is_active : false;
+                                                    @endphp
+                                                    <span class="mr-2">
+                                                        @if ($isActive)
+                                                            <svg class="w-6 h-6 text-green-500" fill="none"
+                                                                stroke="currentColor" viewBox="0 0 24 24"
+                                                                xmlns="http://www.w3.org/2000/svg">
+                                                                <path stroke-linecap="round" stroke-linejoin="round"
+                                                                    stroke-width="2" d="M5 13l4 4L19 7"></path>
+                                                            </svg>
+                                                        @else
+                                                            <svg class="w-6 h-6 text-red-500" fill="none"
+                                                                stroke="currentColor" viewBox="0 0 24 24"
+                                                                xmlns="http://www.w3.org/2000/svg">
+                                                                <path stroke-linecap="round" stroke-linejoin="round"
+                                                                    stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                                                            </svg>
+                                                        @endif
+                                                    </span>
+                                                    {{ $feature->name }}
+                                                </li>
+                                            @endforeach
+                                        </ul>
+                                        <button class="bg-blue-500 text-white px-4 py-2 rounded-md">Choose Plan</button>
+                                    </div>
+                                @endforeach
+                            </div>
+                        @endforeach
+                    @endforeach
+                </div>
+            @endforeach
+        </div>
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,6 +25,7 @@ use App\Http\Controllers\Admin\VacancyCategoryController;
 use App\Http\Controllers\Admin\VacancyController;
 use App\Http\Controllers\Admin\TechnologyController;
 use App\Http\Controllers\Admin\KeyFeatureController;
+use App\Http\Controllers\Admin\FeatureController;
 
 Route::get('/', function () {
     return view('welcome');
@@ -55,6 +56,7 @@ Route::controller(PageController::class)->group(function () {
     Route::get('/job-apply-question', 'job_apply_question')->name('job-apply-question');
     Route::get('/single-software-page', 'single_software_page')->name('single-software-page');
     Route::get('/single-software-plan-page', 'single_software_plan_page')->name('single-software-plan-page');
+    Route::get('/service-plans', 'service_plans')->name('service-plans');
 
     Route::get('/all-softwares', 'all_softwares')->name('all-softwares');
 
@@ -93,6 +95,7 @@ Route::name('admin.')->prefix('admin')->middleware(['auth'])->group(function () 
     Route::resource('vacancies', VacancyController::class);
     Route::resource('technologies', TechnologyController::class);
     Route::resource('key-features', KeyFeatureController::class);
+    Route::resource('features', FeatureController::class);
     Route::resource('trusted-companies', \App\Http\Controllers\Admin\TrustedCompanyController::class);
     Route::resource('clients', \App\Http\Controllers\Admin\ClientController::class);
     Route::resource('faqs', \App\Http\Controllers\Admin\FaqController::class);


### PR DESCRIPTION
This commit introduces a new service price plan comparison page on the frontend, complete with a tabbed interface to switch between service categories.

Key changes include:
- Refactored the PricePlan model to use a many-to-many relationship with a new Feature model, replacing the previous JSON-based approach.
- Implemented a full CRUD interface in the admin panel for managing features.
- Updated the PricePlan admin interface to allow administrators to associate features with specific price plans and set their active status.
- Created a new frontend page that dynamically displays the service plans and their features in a comparison table.