### PR TITLE
feat: Implement software price plan comparison page

### DIFF
--- a/app/Http/Controllers/Admin/PricePlanController.php
+++ b/app/Http/Controllers/Admin/PricePlanController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Models\PricePlan;
 use App\Models\ServiceType;
+use App\Models\Software;
 use App\Models\Feature;
 use Illuminate\Http\Request;
 
@@ -19,8 +20,9 @@ class PricePlanController extends Controller
     public function create()
     {
         $serviceTypes = ServiceType::all();
+        $softwares = Software::all();
         $features = Feature::all();
-        return view('admin.price-plans.create', compact('serviceTypes', 'features'));
+        return view('admin.price-plans.create', compact('serviceTypes', 'softwares', 'features'));
     }
 
     public function store(Request $request)
@@ -57,8 +59,9 @@ class PricePlanController extends Controller
     public function edit(PricePlan $pricePlan)
     {
         $serviceTypes = ServiceType::all();
+        $softwares = Software::all();
         $features = Feature::all();
-        return view('admin.price-plans.edit', compact('pricePlan', 'serviceTypes', 'features'));
+        return view('admin.price-plans.edit', compact('pricePlan', 'serviceTypes', 'softwares', 'features'));
     }
 
     public function update(Request $request, PricePlan $pricePlan)

--- a/app/Http/Controllers/Frontend/PageController.php
+++ b/app/Http/Controllers/Frontend/PageController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Team;
 use Illuminate\Http\Request;
 use App\Models\ServiceCategory;
+use App\Models\SoftwareCategory;
 use App\Models\Feature;
 
 class PageController extends Controller
@@ -87,5 +88,12 @@ class PageController extends Controller
         $serviceCategories = ServiceCategory::with('services.serviceTypes.pricePlans.features')->get();
         $features = Feature::all();
         return view('frontend.service-plans', compact('serviceCategories', 'features'));
+    }
+
+    public function software_plans()
+    {
+        $softwareCategories = SoftwareCategory::with('softwares.pricePlans.features')->get();
+        $features = Feature::all();
+        return view('frontend.software-plans', compact('softwareCategories', 'features'));
     }
 }

--- a/app/Http/Controllers/Frontend/ServiceFrontController.php
+++ b/app/Http/Controllers/Frontend/ServiceFrontController.php
@@ -27,8 +27,8 @@ class ServiceFrontController extends Controller
 
     public function show(Service $service)
     {
-        $service->load('service_category:id,title', 'keyFeatures', 'technologies', 'serviceTypes.pricePlans');
-        $services = Service::with('service_category:id,title')->limit(5)->get();
+        $service->load('category', 'keyFeatures', 'technologies', 'serviceTypes.pricePlans.features');
+        $services = Service::with('category')->limit(5)->get();
 
         return view('frontend.services.show', ['services' => $services, 'service' => $service]);
     }

--- a/app/Http/Controllers/Frontend/SoftwareFrontController.php
+++ b/app/Http/Controllers/Frontend/SoftwareFrontController.php
@@ -27,8 +27,8 @@ class SoftwareFrontController extends Controller
 
     public function show(Software $software)
     {
-        $software->load('software_category:id,title', 'keyFeatures', 'technologies', 'pricePlans');
-        $softwares = Software::with('software_category:id,title')->limit(5)->get();
+        $software->load('category', 'keyFeatures', 'technologies', 'pricePlans.features');
+        $softwares = Software::with('category')->limit(5)->get();
         $groupedPricePlans = $software->pricePlans->groupBy('type');
 
         return view('frontend.softwares.show', ['softwares' => $softwares, 'software' => $software, 'groupedPricePlans' => $groupedPricePlans]);

--- a/app/Models/PricePlan.php
+++ b/app/Models/PricePlan.php
@@ -15,6 +15,11 @@ class PricePlan extends Model
         'name',
         'price',
         'type',
+        'features',
+    ];
+
+    protected $casts = [
+        'features' => 'array',
     ];
 
     public function planable()

--- a/database/seeders/PricePlanSeeder.php
+++ b/database/seeders/PricePlanSeeder.php
@@ -27,7 +27,6 @@ class PricePlanSeeder extends Seeder
                 'planable_type' => ServiceType::class,
                 'name' => 'Basic',
                 'price' => 499.00,
-                'features' => ['Up to 5 pages', 'Responsive design', 'Contact form'],
             ]);
 
             PricePlan::create([
@@ -35,7 +34,6 @@ class PricePlanSeeder extends Seeder
                 'planable_type' => ServiceType::class,
                 'name' => 'Standard',
                 'price' => 999.00,
-                'features' => ['Up to 10 pages', 'CMS integration', 'Basic SEO'],
             ]);
 
             PricePlan::create([
@@ -43,7 +41,6 @@ class PricePlanSeeder extends Seeder
                 'planable_type' => ServiceType::class,
                 'name' => 'Advanced',
                 'price' => 1999.00,
-                'features' => ['Unlimited pages', 'E-commerce functionality', 'Advanced SEO'],
             ]);
         }
 
@@ -60,7 +57,6 @@ class PricePlanSeeder extends Seeder
                 'planable_type' => Software::class,
                 'name' => 'Basic',
                 'price' => 29.00,
-                'features' => ['Up to 10 users', 'Basic features', 'Email support'],
             ]);
 
             PricePlan::create([
@@ -68,7 +64,6 @@ class PricePlanSeeder extends Seeder
                 'planable_type' => Software::class,
                 'name' => 'Standard',
                 'price' => 59.00,
-                'features' => ['Up to 50 users', 'Advanced features', 'Priority email support'],
             ]);
 
             PricePlan::create([
@@ -76,7 +71,6 @@ class PricePlanSeeder extends Seeder
                 'planable_type' => Software::class,
                 'name' => 'Advanced',
                 'price' => 99.00,
-                'features' => ['Unlimited users', 'All features', '24/7 phone support'],
             ]);
         }
     }

--- a/resources/views/admin/price-plans/create.blade.php
+++ b/resources/views/admin/price-plans/create.blade.php
@@ -55,6 +55,7 @@
             <label for="planable_type" class="block text-gray-700">Planable Type</label>
             <select name="planable_type" id="planable_type" class="w-full px-3 py-2 border rounded-md" required>
                 <option value="App\Models\ServiceType">Service Type</option>
+                <option value="App\Models\Software">Software</option>
             </select>
             @error('planable_type')
                 <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
@@ -63,9 +64,7 @@
         <div class="mb-4">
             <label for="planable_id" class="block text-gray-700">Planable</label>
             <select name="planable_id" id="planable_id" class="w-full px-3 py-2 border rounded-md" required>
-                @foreach ($serviceTypes as $serviceType)
-                    <option value="{{ $serviceType->id }}">{{ $serviceType->name }}</option>
-                @endforeach
+                <!-- Options will be populated by script -->
             </select>
             @error('planable_id')
                 <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
@@ -78,6 +77,11 @@
         document.addEventListener('DOMContentLoaded', function() {
             const typeElement = document.getElementById('type');
             const priceContainer = document.getElementById('price-container');
+            const planableTypeElement = document.getElementById('planable_type');
+            const planableIdElement = document.getElementById('planable_id');
+
+            const serviceTypes = @json($serviceTypes);
+            const softwares = @json($softwares);
 
             function togglePriceContainer() {
                 if (typeElement.value === 'fixed') {
@@ -87,9 +91,30 @@
                 }
             }
 
+            function updatePlanableOptions() {
+                planableIdElement.innerHTML = '';
+                if (planableTypeElement.value === 'App\\Models\\ServiceType') {
+                    serviceTypes.forEach(function(serviceType) {
+                        const option = document.createElement('option');
+                        option.value = serviceType.id;
+                        option.textContent = serviceType.name;
+                        planableIdElement.appendChild(option);
+                    });
+                } else if (planableTypeElement.value === 'App\\Models\\Software') {
+                    softwares.forEach(function(software) {
+                        const option = document.createElement('option');
+                        option.value = software.id;
+                        option.textContent = software.name;
+                        planableIdElement.appendChild(option);
+                    });
+                }
+            }
+
             togglePriceContainer();
+            updatePlanableOptions();
 
             typeElement.addEventListener('change', togglePriceContainer);
+            planableTypeElement.addEventListener('change', updatePlanableOptions);
         });
     </script>
 @endsection

--- a/resources/views/admin/price-plans/edit.blade.php
+++ b/resources/views/admin/price-plans/edit.blade.php
@@ -60,6 +60,7 @@
             <label for="planable_type" class="block text-gray-700">Planable Type</label>
             <select name="planable_type" id="planable_type" class="w-full px-3 py-2 border rounded-md" required>
                 <option value="App\Models\ServiceType" @if($pricePlan->planable_type == 'App\Models\ServiceType') selected @endif>Service Type</option>
+                <option value="App\Models\Software" @if($pricePlan->planable_type == 'App\Models\Software') selected @endif>Software</option>
             </select>
             @error('planable_type')
                 <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
@@ -68,9 +69,7 @@
         <div class="mb-4">
             <label for="planable_id" class="block text-gray-700">Planable</label>
             <select name="planable_id" id="planable_id" class="w-full px-3 py-2 border rounded-md" required>
-                @foreach ($serviceTypes as $serviceType)
-                    <option value="{{ $serviceType->id }}" @if($serviceType->id == $pricePlan->planable_id) selected @endif>{{ $serviceType->name }}</option>
-                @endforeach
+                <!-- Options will be populated by script -->
             </select>
             @error('planable_id')
                 <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
@@ -83,6 +82,12 @@
         document.addEventListener('DOMContentLoaded', function() {
             const typeElement = document.getElementById('type');
             const priceContainer = document.getElementById('price-container');
+            const planableTypeElement = document.getElementById('planable_type');
+            const planableIdElement = document.getElementById('planable_id');
+
+            const serviceTypes = @json($serviceTypes);
+            const softwares = @json($softwares);
+            const selectedPlanableId = {{ $pricePlan->planable_id }};
 
             function togglePriceContainer() {
                 if (typeElement.value === 'fixed') {
@@ -92,9 +97,36 @@
                 }
             }
 
+            function updatePlanableOptions() {
+                planableIdElement.innerHTML = '';
+                if (planableTypeElement.value === 'App\\Models\\ServiceType') {
+                    serviceTypes.forEach(function(serviceType) {
+                        const option = document.createElement('option');
+                        option.value = serviceType.id;
+                        option.textContent = serviceType.name;
+                        if (serviceType.id === selectedPlanableId) {
+                            option.selected = true;
+                        }
+                        planableIdElement.appendChild(option);
+                    });
+                } else if (planableTypeElement.value === 'App\\Models\\Software') {
+                    softwares.forEach(function(software) {
+                        const option = document.createElement('option');
+                        option.value = software.id;
+                        option.textContent = software.name;
+                        if (software.id === selectedPlanableId) {
+                            option.selected = true;
+                        }
+                        planableIdElement.appendChild(option);
+                    });
+                }
+            }
+
             togglePriceContainer();
+            updatePlanableOptions();
 
             typeElement.addEventListener('change', togglePriceContainer);
+            planableTypeElement.addEventListener('change', updatePlanableOptions);
         });
     </script>
 @endsection

--- a/resources/views/frontend/services/show.blade.php
+++ b/resources/views/frontend/services/show.blade.php
@@ -71,12 +71,18 @@
                             </div>
                             <p class="body-text-regular-medium text-secondary-600 mb-4">Why should you take this</p>
                             <ul class="space-y-2">
-                                @foreach ($plan->features as $feature)
-                                    <li class="flex items-center">
-                                        <svg class="w-5 h-5 text-green-500 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
-                                        <span class="body-text-regular-medium text-secondary-600">{{ $feature }}</span>
-                                    </li>
-                                @endforeach
+                                @if ($plan->features()->exists())
+                                    @foreach ($plan->features as $feature)
+                                        <li class="flex items-center">
+                                            @if ($feature->pivot->is_active)
+                                                <svg class="w-5 h-5 text-green-500 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                                            @else
+                                                <svg class="w-5 h-5 text-red-500 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
+                                            @endif
+                                            <span class="body-text-regular-medium text-secondary-600">{{ $feature->name }}</span>
+                                        </li>
+                                    @endforeach
+                                @endif
                             </ul>
                             <div class="mt-auto pt-6">
                                 @if($plan->name === 'Advanced')

--- a/resources/views/frontend/software-plans.blade.php
+++ b/resources/views/frontend/software-plans.blade.php
@@ -1,0 +1,61 @@
+@extends('frontend.layouts.app')
+
+@section('content')
+    <div class="container mx-auto px-4 py-8">
+        <h1 class="text-3xl font-bold text-center mb-8">Software Plans</h1>
+
+        <div x-data="{ activeTab: {{ $softwareCategories->first()->id }} }">
+            <div class="flex justify-center mb-8">
+                @foreach ($softwareCategories as $category)
+                    <button @click="activeTab = {{ $category->id }}"
+                        :class="{ 'bg-blue-500 text-white': activeTab === {{ $category->id }}, 'bg-gray-200 text-gray-700': activeTab !== {{ $category->id }} }"
+                        class="px-4 py-2 rounded-md mr-4">{{ $category->title }}</button>
+                @endforeach
+            </div>
+
+            @foreach ($softwareCategories as $category)
+                <div x-show="activeTab === {{ $category->id }}">
+                    @foreach ($category->softwares as $software)
+                        <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+                            @foreach ($software->pricePlans as $plan)
+                                <div class="bg-white rounded-lg shadow-md p-6">
+                                    <h2 class="text-xl font-bold mb-4">{{ $plan->name }}</h2>
+                                    <p class="text-3xl font-bold mb-4">${{ $plan->price }}</p>
+                                    <ul class="mb-4">
+                                        @foreach ($features as $feature)
+                                            <li class="flex items-center mb-2">
+                                                @php
+                                                    $planFeature = $plan->features->firstWhere('id', $feature->id);
+                                                    $isActive = $planFeature ? $planFeature->pivot->is_active : false;
+                                                @endphp
+                                                <span class="mr-2">
+                                                    @if ($isActive)
+                                                        <svg class="w-6 h-6 text-green-500" fill="none"
+                                                            stroke="currentColor" viewBox="0 0 24 24"
+                                                            xmlns="http://www.w3.org/2000/svg">
+                                                            <path stroke-linecap="round" stroke-linejoin="round"
+                                                                stroke-width="2" d="M5 13l4 4L19 7"></path>
+                                                        </svg>
+                                                    @else
+                                                        <svg class="w-6 h-6 text-red-500" fill="none"
+                                                            stroke="currentColor" viewBox="0 0 24 24"
+                                                            xmlns="http://www.w3.org/2000/svg">
+                                                            <path stroke-linecap="round" stroke-linejoin="round"
+                                                                stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                                                        </svg>
+                                                    @endif
+                                                </span>
+                                                {{ $feature->name }}
+                                            </li>
+                                        @endforeach
+                                    </ul>
+                                    <button class="bg-blue-500 text-white px-4 py-2 rounded-md">Choose Plan</button>
+                                </div>
+                            @endforeach
+                        </div>
+                    @endforeach
+                </div>
+            @endforeach
+        </div>
+    </div>
+@endsection

--- a/resources/views/frontend/softwares/show.blade.php
+++ b/resources/views/frontend/softwares/show.blade.php
@@ -71,12 +71,18 @@
                             </div>
                             <p class="body-text-regular-medium text-secondary-600 mb-4">Why should you take this</p>
                             <ul class="space-y-2">
-                                @foreach ($plan->features as $feature)
-                                    <li class="flex items-center">
-                                        <svg class="w-5 h-5 text-green-500 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
-                                        <span class="body-text-regular-medium text-secondary-600">{{ $feature }}</span>
-                                    </li>
-                                @endforeach
+                                @if ($plan->features()->exists())
+                                    @foreach ($plan->features as $feature)
+                                        <li class="flex items-center">
+                                            @if ($feature->pivot->is_active)
+                                                <svg class="w-5 h-5 text-green-500 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
+                                            @else
+                                                <svg class="w-5 h-5 text-red-500 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
+                                            @endif
+                                            <span class="body-text-regular-medium text-secondary-600">{{ $feature->name }}</span>
+                                        </li>
+                                    @endforeach
+                                @endif
                             </ul>
                             <div class="mt-auto pt-6">
                                 @if($plan->name === 'Advanced')

--- a/routes/web.php
+++ b/routes/web.php
@@ -57,6 +57,7 @@ Route::controller(PageController::class)->group(function () {
     Route::get('/single-software-page', 'single_software_page')->name('single-software-page');
     Route::get('/single-software-plan-page', 'single_software_plan_page')->name('single-software-plan-page');
     Route::get('/service-plans', 'service_plans')->name('service-plans');
+    Route::get('/software-plans', 'software_plans')->name('software-plans');
 
     Route::get('/all-softwares', 'all_softwares')->name('all-softwares');
 


### PR DESCRIPTION
This commit introduces a new software price plan comparison page on the frontend, complete with a tabbed interface to switch between software categories. It also updates the software detail page to display price plan features and ensures backward compatibility. The admin panel has been updated to support creating and editing price plans for software.