### PR TITLE
feat: Implement dynamic page content across the application

### DIFF
--- a/app/Http/Controllers/Admin/PageSettingController.php
+++ b/app/Http/Controllers/Admin/PageSettingController.php
@@ -1,0 +1,588 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Controllers\Traits\FileUploadTrait;
+use App\Models\PageSetting;
+use Illuminate\Http\Request;
+
+class PageSettingController extends Controller
+{
+    use FileUploadTrait;
+
+    private function updatePageSettings(Request $request, $pageName, $fields, $imageFields = [])
+    {
+        $page = PageSetting::firstOrNew(['page_name' => $pageName]);
+        $settings = $page->settings ?? [];
+
+        foreach ($fields as $field) {
+            if ($request->has($field)) {
+                $settings[$field] = $request->input($field);
+            }
+        }
+
+        foreach ($imageFields as $imageField) {
+            if ($request->hasFile($imageField['name'])) {
+                $settings[$imageField['name']] = $this->uploadFile($request, $imageField['name'], $imageField['path']);
+            }
+        }
+
+        $page->settings = $settings;
+        $page->save();
+    }
+
+    public function about()
+    {
+        $aboutPage = PageSetting::where('page_name', 'about')->first();
+        $aboutSettings = $aboutPage ? $aboutPage->settings : [];
+
+        return view('admin.pages.about', compact('aboutSettings'));
+    }
+
+    public function aboutUpdate(Request $request)
+    {
+        $request->validate([
+            'page_title' => 'required|string|max:255',
+            'about_us_title' => 'required|string|max:255',
+            'about_us_description' => 'required|string',
+            'about_us_image' => 'nullable|image|mimes:jpeg,png,jpg,gif,svg|max:2048',
+            'achievement_title' => 'required|string|max:255',
+            'achievement_description' => 'required|string',
+            'achievement_one_title' => 'required|string|max:255',
+            'achievement_one_value' => 'required|string|max:255',
+            'achievement_two_title' => 'required|string|max:255',
+            'achievement_two_value' => 'required|string|max:255',
+            'achievement_three_title' => 'required|string|max:255',
+            'achievement_three_value' => 'required|string|max:255',
+            'journey_title' => 'required|string|max:255',
+            'journey_description' => 'required|string',
+            'journey_one_title' => 'required|string|max:255',
+            'journey_one_description' => 'required|string',
+            'journey_two_title' => 'required|string|max:255',
+            'journey_two_description' => 'required|string',
+            'journey_three_title' => 'required|string|max:255',
+            'journey_three_description' => 'required|string',
+            'team_title' => 'required|string|max:255',
+        ]);
+
+        $fields = [
+            'page_title', 'about_us_title', 'about_us_description', 'achievement_title',
+            'achievement_description', 'achievement_one_title', 'achievement_one_value',
+            'achievement_two_title', 'achievement_two_value', 'achievement_three_title',
+            'achievement_three_value', 'journey_title', 'journey_description',
+            'journey_one_title', 'journey_one_description', 'journey_two_title',
+            'journey_two_description', 'journey_three_title', 'journey_three_description',
+            'team_title'
+        ];
+
+        $imageFields = [
+            ['name' => 'about_us_image', 'path' => 'uploads/about']
+        ];
+
+        $this->updatePageSettings($request, 'about', $fields, $imageFields);
+
+        return redirect()->back()->with('success', 'About Us page settings updated successfully.');
+    }
+
+    public function home()
+    {
+        $homePage = PageSetting::where('page_name', 'home')->first();
+        $homeSettings = $homePage ? $homePage->settings : [];
+
+        return view('admin.pages.home', compact('homeSettings'));
+    }
+
+    public function homeUpdate(Request $request)
+    {
+        $request->validate([
+            'page_title' => 'required|string|max:255',
+            'hero_title' => 'required|string|max:255',
+            'hero_subtitle' => 'required|string|max:255',
+            'hero_button_text' => 'required|string|max:255',
+            'services_title' => 'required|string|max:255',
+            'services_description' => 'required|string',
+            'software_title' => 'required|string|max:255',
+            'software_description' => 'required|string',
+            'projects_title' => 'required|string|max:255',
+            'projects_description' => 'required|string',
+            'contact_title' => 'required|string|max:255',
+            'client_reviews_title' => 'required|string|max:255',
+            'client_reviews_description' => 'required|string',
+            'hero_card_description' => 'required|string',
+            'hero_card_one_title' => 'required|string|max:255',
+            'hero_card_one_value' => 'required|string|max:255',
+            'hero_card_one_description' => 'required|string',
+            'hero_card_two_title' => 'required|string|max:255',
+            'hero_card_two_value' => 'required|string|max:255',
+            'hero_card_two_description' => 'required|string',
+            'hero_card_three_title' => 'required|string|max:255',
+            'hero_card_three_value' => 'required|string|max:255',
+            'hero_card_three_description' => 'required|string',
+            'search_title' => 'required|string|max:255',
+            'values_title' => 'required|string|max:255',
+            'working_process_title' => 'required|string|max:255',
+            'faq_title' => 'required|string|max:255',
+            'articles_title' => 'required|string|max:255',
+            'articles_description' => 'required|string',
+        ]);
+
+        $fields = [
+            'page_title', 'hero_title', 'hero_subtitle', 'hero_button_text',
+            'services_title', 'services_description', 'software_title',
+            'software_description', 'projects_title', 'projects_description',
+            'contact_title', 'client_reviews_title', 'client_reviews_description',
+            'hero_card_description', 'hero_card_one_title', 'hero_card_one_value',
+            'hero_card_one_description', 'hero_card_two_title', 'hero_card_two_value',
+            'hero_card_two_description', 'hero_card_three_title',
+            'hero_card_three_value', 'hero_card_three_description', 'search_title',
+            'values_title', 'working_process_title', 'faq_title', 'articles_title',
+            'articles_description'
+        ];
+
+        $this->updatePageSettings($request, 'home', $fields);
+
+        return redirect()->back()->with('success', 'Home page settings updated successfully.');
+    }
+
+    public function contact()
+    {
+        $contactPage = PageSetting::where('page_name', 'contact')->first();
+        $contactSettings = $contactPage ? $contactPage->settings : [];
+
+        return view('admin.pages.contact', compact('contactSettings'));
+    }
+
+    public function contactUpdate(Request $request)
+    {
+        $request->validate([
+            'page_title' => 'required|string|max:255',
+            'contact_title' => 'required|string|max:255',
+            'contact_description' => 'required|string',
+            'contact_email' => 'required|email|max:255',
+            'contact_phone' => 'required|string|max:255',
+            'contact_address' => 'required|string|max:255',
+            'contact_map_iframe_url' => 'required|string',
+        ]);
+
+        $fields = [
+            'page_title', 'contact_title', 'contact_description', 'contact_email',
+            'contact_phone', 'contact_address', 'contact_map_iframe_url'
+        ];
+
+        $this->updatePageSettings($request, 'contact', $fields);
+
+        return redirect()->back()->with('success', 'Contact page settings updated successfully.');
+    }
+
+    public function notFound()
+    {
+        $notFoundPage = PageSetting::where('page_name', '404')->first();
+        $notFoundSettings = $notFoundPage ? $notFoundPage->settings : [];
+
+        return view('admin.pages.404', compact('notFoundSettings'));
+    }
+
+    public function notFoundUpdate(Request $request)
+    {
+        $request->validate([
+            'page_title' => 'required|string|max:255',
+            '404_title' => 'required|string|max:255',
+            '404_description' => 'required|string',
+            '404_image' => 'nullable|image|mimes:jpeg,png,jpg,gif,svg|max:2048',
+        ]);
+
+        $fields = ['page_title', '404_title', '404_description'];
+        $imageFields = [
+            ['name' => '404_image', 'path' => 'uploads/404']
+        ];
+
+        $this->updatePageSettings($request, '404', $fields, $imageFields);
+
+        return redirect()->back()->with('success', '404 page settings updated successfully.');
+    }
+
+    public function terms()
+    {
+        $termsPage = PageSetting::where('page_name', 'terms')->first();
+        $termsSettings = $termsPage ? $termsPage->settings : [];
+
+        return view('admin.pages.terms', compact('termsSettings'));
+    }
+
+    public function termsUpdate(Request $request)
+    {
+        $request->validate([
+            'page_title' => 'required|string|max:255',
+            'terms_title' => 'required|string|max:255',
+            'terms_content' => 'required|string',
+        ]);
+
+        $fields = ['page_title', 'terms_title', 'terms_content'];
+        $this->updatePageSettings($request, 'terms', $fields);
+
+        return redirect()->back()->with('success', 'Terms & Conditions page settings updated successfully.');
+    }
+
+    public function privacy()
+    {
+        $privacyPage = PageSetting::where('page_name', 'privacy')->first();
+        $privacySettings = $privacyPage ? $privacyPage->settings : [];
+
+        return view('admin.pages.privacy', compact('privacySettings'));
+    }
+
+    public function privacyUpdate(Request $request)
+    {
+        $request->validate([
+            'page_title' => 'required|string|max:255',
+            'privacy_title' => 'required|string|max:255',
+            'privacy_content' => 'required|string',
+        ]);
+
+        $fields = ['page_title', 'privacy_title', 'privacy_content'];
+        $this->updatePageSettings($request, 'privacy', $fields);
+
+        return redirect()->back()->with('success', 'Privacy Policy page settings updated successfully.');
+    }
+
+    public function services()
+    {
+        $servicesPage = PageSetting::where('page_name', 'services')->first();
+        $servicesSettings = $servicesPage ? $servicesPage->settings : [];
+
+        return view('admin.pages.services', compact('servicesSettings'));
+    }
+
+    public function servicesUpdate(Request $request)
+    {
+        $request->validate([
+            'page_title' => 'required|string|max:255',
+            'title' => 'required|string|max:255',
+            'description' => 'required|string',
+        ]);
+
+        $fields = ['page_title', 'title', 'description'];
+        $this->updatePageSettings($request, 'services', $fields);
+
+        return redirect()->back()->with('success', 'Services page settings updated successfully.');
+    }
+
+    public function articles()
+    {
+        $articlesPage = PageSetting::where('page_name', 'articles')->first();
+        $articlesSettings = $articlesPage ? $articlesPage->settings : [];
+
+        return view('admin.pages.articles', compact('articlesSettings'));
+    }
+
+    public function articlesUpdate(Request $request)
+    {
+        $request->validate([
+            'page_title' => 'required|string|max:255',
+            'title' => 'required|string|max:255',
+            'description' => 'required|string',
+        ]);
+
+        $fields = ['page_title', 'title', 'description'];
+        $this->updatePageSettings($request, 'articles', $fields);
+
+        return redirect()->back()->with('success', 'Articles page settings updated successfully.');
+    }
+
+    public function softwares()
+    {
+        $softwaresPage = PageSetting::where('page_name', 'softwares')->first();
+        $softwaresSettings = $softwaresPage ? $softwaresPage->settings : [];
+
+        return view('admin.pages.softwares', compact('softwaresSettings'));
+    }
+
+    public function softwaresUpdate(Request $request)
+    {
+        $request->validate([
+            'page_title' => 'required|string|max:255',
+            'title' => 'required|string|max:255',
+            'description' => 'required|string',
+        ]);
+
+        $fields = ['page_title', 'title', 'description'];
+        $this->updatePageSettings($request, 'softwares', $fields);
+
+        return redirect()->back()->with('success', 'Software page settings updated successfully.');
+    }
+
+    public function projects()
+    {
+        $projectsPage = PageSetting::where('page_name', 'projects')->first();
+        $projectsSettings = $projectsPage ? $projectsPage->settings : [];
+
+        return view('admin.pages.projects', compact('projectsSettings'));
+    }
+
+    public function projectsUpdate(Request $request)
+    {
+        $request->validate([
+            'page_title' => 'required|string|max:255',
+            'title' => 'required|string|max:255',
+            'description' => 'required|string',
+        ]);
+
+        $fields = ['page_title', 'title', 'description'];
+        $this->updatePageSettings($request, 'projects', $fields);
+
+        return redirect()->back()->with('success', 'Projects page settings updated successfully.');
+    }
+
+    public function allSoftwares()
+    {
+        $allSoftwaresPage = PageSetting::where('page_name', 'all-softwares')->first();
+        $allSoftwaresSettings = $allSoftwaresPage ? $allSoftwaresPage->settings : [];
+
+        return view('admin.pages.all-softwares', compact('allSoftwaresSettings'));
+    }
+
+    public function allSoftwaresUpdate(Request $request)
+    {
+        $request->validate([
+            'page_title' => 'required|string|max:255',
+            'title' => 'required|string|max:255',
+            'description' => 'required|string',
+            'section_title' => 'required|string|max:255',
+        ]);
+
+        $fields = ['page_title', 'title', 'description', 'section_title'];
+        $this->updatePageSettings($request, 'all-softwares', $fields);
+
+        return redirect()->back()->with('success', 'All Software page settings updated successfully.');
+    }
+
+    public function customSoftware()
+    {
+        $customSoftwarePage = PageSetting::where('page_name', 'custom-software')->first();
+        $customSoftwareSettings = $customSoftwarePage ? $customSoftwarePage->settings : [];
+
+        return view('admin.pages.custom-software', compact('customSoftwareSettings'));
+    }
+
+    public function customSoftwareUpdate(Request $request)
+    {
+        $request->validate([
+            'page_title' => 'required|string|max:255',
+            'title' => 'required|string|max:255',
+            'description' => 'required|string',
+            'why_choose_title' => 'required|string|max:255',
+            'why_choose_description' => 'required|string',
+            'key_features_title' => 'required|string|max:255',
+            'plans_title' => 'required|string|max:255',
+            'technologies_title' => 'required|string|max:255',
+        ]);
+
+        $fields = [
+            'page_title', 'title', 'description', 'why_choose_title',
+            'why_choose_description', 'key_features_title', 'plans_title',
+            'technologies_title'
+        ];
+        $this->updatePageSettings($request, 'custom-software', $fields);
+
+        return redirect()->back()->with('success', 'Custom Software page settings updated successfully.');
+    }
+
+    public function letsDiscuss()
+    {
+        $letsDiscussPage = PageSetting::where('page_name', 'lets-discuss')->first();
+        $letsDiscussSettings = $letsDiscussPage ? $letsDiscussPage->settings : [];
+
+        return view('admin.pages.lets-discuss', compact('letsDiscussSettings'));
+    }
+
+    public function letsDiscussUpdate(Request $request)
+    {
+        $request->validate([
+            'page_title' => 'required|string|max:255',
+            'title' => 'required|string|max:255',
+            'subtitle' => 'required|string|max:255',
+        ]);
+
+        $fields = ['page_title', 'title', 'subtitle'];
+        $this->updatePageSettings($request, 'lets-discuss', $fields);
+
+        return redirect()->back()->with('success', 'Let\'s Discuss page settings updated successfully.');
+    }
+
+    public function thankYou()
+    {
+        $thankYouPage = PageSetting::where('page_name', 'thank-you')->first();
+        $thankYouSettings = $thankYouPage ? $thankYouPage->settings : [];
+
+        return view('admin.pages.thank-you', compact('thankYouSettings'));
+    }
+
+    public function thankYouUpdate(Request $request)
+    {
+        $request->validate([
+            'page_title' => 'required|string|max:255',
+            'title' => 'required|string|max:255',
+            'subtitle' => 'required|string|max:255',
+        ]);
+
+        $fields = ['page_title', 'title', 'subtitle'];
+        $this->updatePageSettings($request, 'thank-you', $fields);
+
+        return redirect()->back()->with('success', 'Thank You page settings updated successfully.');
+    }
+
+    public function servicePlans()
+    {
+        $servicePlansPage = PageSetting::where('page_name', 'service-plans')->first();
+        $servicePlansSettings = $servicePlansPage ? $servicePlansPage->settings : [];
+
+        return view('admin.pages.service-plans', compact('servicePlansSettings'));
+    }
+
+    public function servicePlansUpdate(Request $request)
+    {
+        $request->validate([
+            'page_title' => 'required|string|max:255',
+            'title' => 'required|string|max:255',
+        ]);
+
+        $fields = ['page_title', 'title'];
+        $this->updatePageSettings($request, 'service-plans', $fields);
+
+        return redirect()->back()->with('success', 'Service Plans page settings updated successfully.');
+    }
+
+    public function softwarePlans()
+    {
+        $softwarePlansPage = PageSetting::where('page_name', 'software-plans')->first();
+        $softwarePlansSettings = $softwarePlansPage ? $softwarePlansPage->settings : [];
+
+        return view('admin.pages.software-plans', compact('softwarePlansSettings'));
+    }
+
+    public function softwarePlansUpdate(Request $request)
+    {
+        $request->validate([
+            'page_title' => 'required|string|max:255',
+            'title' => 'required|string|max:255',
+        ]);
+
+        $fields = ['page_title', 'title'];
+        $this->updatePageSettings($request, 'software-plans', $fields);
+
+        return redirect()->back()->with('success', 'Software Plans page settings updated successfully.');
+    }
+
+    public function careers()
+    {
+        $careersPage = PageSetting::where('page_name', 'careers')->first();
+        $careersSettings = $careersPage ? $careersPage->settings : [];
+
+        return view('admin.pages.careers', compact('careersSettings'));
+    }
+
+    public function careersUpdate(Request $request)
+    {
+        $request->validate([
+            'page_title' => 'required|string|max:255',
+            'title' => 'required|string|max:255',
+        ]);
+
+        $fields = ['page_title', 'title'];
+        $this->updatePageSettings($request, 'careers', $fields);
+
+        return redirect()->back()->with('success', 'Careers page settings updated successfully.');
+    }
+
+    public function serviceDetail()
+    {
+        $serviceDetailPage = PageSetting::where('page_name', 'service-detail')->first();
+        $serviceDetailSettings = $serviceDetailPage ? $serviceDetailPage->settings : [];
+
+        return view('admin.pages.service-detail', compact('serviceDetailSettings'));
+    }
+
+    public function serviceDetailUpdate(Request $request)
+    {
+        $request->validate([
+            'page_title' => 'required|string|max:255',
+            'key_features_title' => 'required|string|max:255',
+            'technologies_title' => 'required|string|max:255',
+            'service_plans_title' => 'required|string|max:255',
+        ]);
+
+        $fields = ['page_title', 'key_features_title', 'technologies_title', 'service_plans_title'];
+        $this->updatePageSettings($request, 'service-detail', $fields);
+
+        return redirect()->back()->with('success', 'Service Detail page settings updated successfully.');
+    }
+
+    public function articleDetail()
+    {
+        $articleDetailPage = PageSetting::where('page_name', 'article-detail')->first();
+        $articleDetailSettings = $articleDetailPage ? $articleDetailPage->settings : [];
+
+        return view('admin.pages.article-detail', compact('articleDetailSettings'));
+    }
+
+    public function articleDetailUpdate(Request $request)
+    {
+        $request->validate([
+            'page_title' => 'required|string|max:255',
+            'other_articles_title' => 'required|string|max:255',
+            'other_articles_description' => 'required|string',
+        ]);
+
+        $fields = ['page_title', 'other_articles_title', 'other_articles_description'];
+        $this->updatePageSettings($request, 'article-detail', $fields);
+
+        return redirect()->back()->with('success', 'Article Detail page settings updated successfully.');
+    }
+
+    public function softwareDetail()
+    {
+        $softwareDetailPage = PageSetting::where('page_name', 'software-detail')->first();
+        $softwareDetailSettings = $softwareDetailPage ? $softwareDetailPage->settings : [];
+
+        return view('admin.pages.software-detail', compact('softwareDetailSettings'));
+    }
+
+    public function softwareDetailUpdate(Request $request)
+    {
+        $request->validate([
+            'page_title' => 'required|string|max:255',
+            'key_features_title' => 'required|string|max:255',
+            'technologies_title' => 'required|string|max:255',
+            'software_plans_title' => 'required|string|max:255',
+        ]);
+
+        $fields = ['page_title', 'key_features_title', 'technologies_title', 'software_plans_title'];
+        $this->updatePageSettings($request, 'software-detail', $fields);
+
+        return redirect()->back()->with('success', 'Software Detail page settings updated successfully.');
+    }
+
+    public function projectDetail()
+    {
+        $projectDetailPage = PageSetting::where('page_name', 'project-detail')->first();
+        $projectDetailSettings = $projectDetailPage ? $projectDetailPage->settings : [];
+
+        return view('admin.pages.project-detail', compact('projectDetailSettings'));
+    }
+
+    public function projectDetailUpdate(Request $request)
+    {
+        $request->validate([
+            'page_title' => 'required|string|max:255',
+            'client_reviews_title' => 'required|string|max:255',
+            'other_projects_title' => 'required|string|max:255',
+            'other_projects_description' => 'required|string',
+        ]);
+
+        $fields = ['page_title', 'client_reviews_title', 'other_projects_title', 'other_projects_description'];
+        $this->updatePageSettings($request, 'project-detail', $fields);
+
+        return redirect()->back()->with('success', 'Project Detail page settings updated successfully.');
+    }
+}

--- a/app/Http/Controllers/Frontend/ArticleFrontController.php
+++ b/app/Http/Controllers/Frontend/ArticleFrontController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Frontend;
 use App\Http\Controllers\Controller;
 use App\Models\Article;
 use App\Models\ArticleCategory;
+use App\Models\PageSetting;
 use Illuminate\Http\Request;
 
 class ArticleFrontController extends Controller
@@ -22,7 +23,10 @@ class ArticleFrontController extends Controller
             })
             ->paginate(6);
 
-        return view('frontend.articles.index', ['articles' => $articles, 'article_categories' => $article_categories]);
+        $articlesPage = PageSetting::where('page_name', 'articles')->first();
+        $articlesSettings = $articlesPage ? $articlesPage->settings : [];
+
+        return view('frontend.articles.index', ['articles' => $articles, 'article_categories' => $article_categories, 'articlesSettings' => $articlesSettings]);
     }
 
     // Show
@@ -30,7 +34,9 @@ class ArticleFrontController extends Controller
     {
         $article->load('article_category:id,title', 'tags');
         $articles = Article::with('article_category:id,title')->limit(5)->get();
+        $articleDetailPage = PageSetting::where('page_name', 'article-detail')->first();
+        $articleDetailSettings = $articleDetailPage ? $articleDetailPage->settings : [];
 
-        return view('frontend.articles.show', ['articles' => $articles, 'article' => $article]);
+        return view('frontend.articles.show', ['articles' => $articles, 'article' => $article, 'articleDetailSettings' => $articleDetailSettings]);
     }
 }

--- a/app/Http/Controllers/Frontend/CareerFrontController.php
+++ b/app/Http/Controllers/Frontend/CareerFrontController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Frontend;
 
 use App\Http\Controllers\Controller;
+use App\Models\PageSetting;
 use App\Models\Vacancy;
 use App\Models\VacancyCategory;
 use Illuminate\Http\Request;
@@ -24,7 +25,10 @@ class CareerFrontController extends Controller
             })
             ->paginate(6);
 
-        return view('frontend.careers.index', ['vacancies' => $vacancies, 'vacancy_categories' => $vacancy_categories]);
+        $careersPage = PageSetting::where('page_name', 'careers')->first();
+        $careersSettings = $careersPage ? $careersPage->settings : [];
+
+        return view('frontend.careers.index', ['vacancies' => $vacancies, 'vacancy_categories' => $vacancy_categories, 'careersSettings' => $careersSettings]);
     }
 
     // Show

--- a/app/Http/Controllers/Frontend/ContactController.php
+++ b/app/Http/Controllers/Frontend/ContactController.php
@@ -3,13 +3,17 @@
 namespace App\Http\Controllers\Frontend;
 
 use App\Http/Controllers\Controller;
+use App\Models\PageSetting;
 use Illuminate\Http\Request;
 
 class ContactController extends Controller
 {
     public function contact()
     {
-        return view('frontend.contact');
+        $contactPage = PageSetting::where('page_name', 'contact')->first();
+        $contactSettings = $contactPage ? $contactPage->settings : [];
+
+        return view('frontend.contact', compact('contactSettings'));
     }
 
     public function contact_submit(Request $request)

--- a/app/Http/Controllers/Frontend/HomeController.php
+++ b/app/Http/Controllers/Frontend/HomeController.php
@@ -5,9 +5,13 @@ namespace App\Http\Controllers\Frontend;
 use App\Http\Controllers\Controller;
 use App\Models\Article;
 use App\Models\ClientReview;
+use App\Models\Faq;
+use App\Models\PageSetting;
 use App\Models\Project;
 use App\Models\Service;
 use App\Models\Software;
+use App\Models\Value;
+use App\Models\WorkingProcess;
 
 class HomeController extends Controller
 {
@@ -18,6 +22,14 @@ class HomeController extends Controller
         $softwares = Software::with('software_category:id,title')->latest()->limit(8)->get();
         $services = Service::with('service_category:id,title')->latest()->limit(8)->get();
         $client_reviews = ClientReview::latest()->limit(8)->get();
+        $values = Value::latest()->limit(4)->get();
+        $working_processes = WorkingProcess::latest()->limit(4)->get();
+        $faqs = Faq::latest()->limit(3)->get();
+
+        $homePage = PageSetting::where('page_name', 'home')->first();
+        $homeSettings = $homePage ? $homePage->settings : [];
+        $contactPage = PageSetting::where('page_name', 'contact')->first();
+        $contactSettings = $contactPage ? $contactPage->settings : [];
 
         return view('frontend.home', [
             'projects' => $projects,
@@ -25,6 +37,11 @@ class HomeController extends Controller
             'services' => $services,
             'articles' => $articles,
             'client_reviews' => $client_reviews,
+            'homeSettings' => $homeSettings,
+            'values' => $values,
+            'working_processes' => $working_processes,
+            'faqs' => $faqs,
+            'contactSettings' => $contactSettings,
         ]);
     }
 }

--- a/app/Http/Controllers/Frontend/PageController.php
+++ b/app/Http/Controllers/Frontend/PageController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Frontend;
 
 use App\Http\Controllers\Controller;
+use App\Models\PageSetting;
 use App\Models\Team;
 use Illuminate\Http\Request;
 use App\Models\ServiceCategory;
@@ -14,18 +15,26 @@ class PageController extends Controller
     public function about()
     {
         $teams = Team::get();
+        $aboutPage = PageSetting::where('page_name', 'about')->first();
+        $aboutSettings = $aboutPage ? $aboutPage->settings : [];
 
-        return view('frontend.about', ['teams' => $teams]);
+        return view('frontend.about', compact('teams', 'aboutSettings'));
     }
 
     public function terms_conditions()
     {
-        return view('frontend.terms-conditions');
+        $termsPage = PageSetting::where('page_name', 'terms')->first();
+        $termsSettings = $termsPage ? $termsPage->settings : [];
+
+        return view('frontend.terms-conditions', compact('termsSettings'));
     }
 
     public function privacy_policy()
     {
-        return view('frontend.privacy-policy');
+        $privacyPage = PageSetting::where('page_name', 'privacy')->first();
+        $privacySettings = $privacyPage ? $privacyPage->settings : [];
+
+        return view('frontend.privacy-policy', compact('privacySettings'));
     }
 
     public function job_apply_question()
@@ -45,12 +54,18 @@ class PageController extends Controller
 
     public function all_softwares()
     {
-        return view('frontend.all-softwares');
+        $allSoftwaresPage = PageSetting::where('page_name', 'all-softwares')->first();
+        $allSoftwaresSettings = $allSoftwaresPage ? $allSoftwaresPage->settings : [];
+
+        return view('frontend.all-softwares', compact('allSoftwaresSettings'));
     }
 
     public function lets_discuss()
     {
-        return view('frontend.lets-discuss');
+        $letsDiscussPage = PageSetting::where('page_name', 'lets-discuss')->first();
+        $letsDiscussSettings = $letsDiscussPage ? $letsDiscussPage->settings : [];
+
+        return view('frontend.lets-discuss', compact('letsDiscussSettings'));
     }
 
     public function confirmation()
@@ -65,7 +80,10 @@ class PageController extends Controller
 
     public function thankYouPage()
     {
-        return view('frontend.thank-you-page');
+        $thankYouPage = PageSetting::where('page_name', 'thank-you')->first();
+        $thankYouSettings = $thankYouPage ? $thankYouPage->settings : [];
+
+        return view('frontend.thank-you-page', compact('thankYouSettings'));
     }
 
     public function maintenancePage()
@@ -80,20 +98,27 @@ class PageController extends Controller
 
     public function custom_software()
     {
-        return view('frontend.custom-software');
+        $customSoftwarePage = PageSetting::where('page_name', 'custom-software')->first();
+        $customSoftwareSettings = $customSoftwarePage ? $customSoftwarePage->settings : [];
+
+        return view('frontend.custom-software', compact('customSoftwareSettings'));
     }
 
     public function service_plans()
     {
         $serviceCategories = ServiceCategory::with('services.serviceTypes.pricePlans.features')->get();
         $features = Feature::all();
-        return view('frontend.service-plans', compact('serviceCategories', 'features'));
+        $servicePlansPage = PageSetting::where('page_name', 'service-plans')->first();
+        $servicePlansSettings = $servicePlansPage ? $servicePlansPage->settings : [];
+        return view('frontend.service-plans', compact('serviceCategories', 'features', 'servicePlansSettings'));
     }
 
     public function software_plans()
     {
         $softwareCategories = SoftwareCategory::with('softwares.pricePlans.features')->get();
         $features = Feature::all();
-        return view('frontend.software-plans', compact('softwareCategories', 'features'));
+        $softwarePlansPage = PageSetting::where('page_name', 'software-plans')->first();
+        $softwarePlansSettings = $softwarePlansPage ? $softwarePlansPage->settings : [];
+        return view('frontend.software-plans', compact('softwareCategories', 'features', 'softwarePlansSettings'));
     }
 }

--- a/app/Http/Controllers/Frontend/ProjectFrontController.php
+++ b/app/Http/Controllers/Frontend/ProjectFrontController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Frontend;
 
 use App\Http\Controllers\Controller;
+use App\Models\PageSetting;
 use App\Models\Project;
 use App\Models\ProjectCategory;
 use Illuminate\Http\Request;
@@ -22,14 +23,19 @@ class ProjectFrontController extends Controller
             })
             ->paginate(6);
 
-        return view('frontend.projects.index', ['projects' => $projects, 'project_categories' => $project_categories]);
+        $projectsPage = PageSetting::where('page_name', 'projects')->first();
+        $projectsSettings = $projectsPage ? $projectsPage->settings : [];
+
+        return view('frontend.projects.index', ['projects' => $projects, 'project_categories' => $project_categories, 'projectsSettings' => $projectsSettings]);
     }
 
     public function show(Project $project)
     {
         $project->load('category:id,title');
         $projects = Project::with('category:id,title', 'clientReview')->limit(5)->get();
+        $projectDetailPage = PageSetting::where('page_name', 'project-detail')->first();
+        $projectDetailSettings = $projectDetailPage ? $projectDetailPage->settings : [];
 
-        return view('frontend.projects.show', ['project' => $project, 'projects' => $projects]);
+        return view('frontend.projects.show', ['project' => $project, 'projects' => $projects, 'projectDetailSettings' => $projectDetailSettings]);
     }
 }

--- a/app/Http/Controllers/Frontend/ServiceFrontController.php
+++ b/app/Http/Controllers/Frontend/ServiceFrontController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Frontend;
 
 use App\Http\Controllers\Controller;
+use App\Models\PageSetting;
 use App\Models\Service;
 use App\Models\ServiceCategory;
 use Illuminate\Http\Request;
@@ -22,14 +23,19 @@ class ServiceFrontController extends Controller
             })
             ->paginate(6);
 
-        return view('frontend.services.index', ['services' => $services, 'service_categories' => $service_categories]);
+        $servicesPage = PageSetting::where('page_name', 'services')->first();
+        $servicesSettings = $servicesPage ? $servicesPage->settings : [];
+
+        return view('frontend.services.index', ['services' => $services, 'service_categories' => $service_categories, 'servicesSettings' => $servicesSettings]);
     }
 
     public function show(Service $service)
     {
         $service->load('service_category', 'keyFeatures', 'technologies', 'serviceTypes.pricePlans.features');
         $services = Service::with('service_category')->limit(5)->get();
+        $serviceDetailPage = PageSetting::where('page_name', 'service-detail')->first();
+        $serviceDetailSettings = $serviceDetailPage ? $serviceDetailPage->settings : [];
 
-        return view('frontend.services.show', ['services' => $services, 'service' => $service]);
+        return view('frontend.services.show', ['services' => $services, 'service' => $service, 'serviceDetailSettings' => $serviceDetailSettings]);
     }
 }

--- a/app/Http/Controllers/Frontend/SoftwareFrontController.php
+++ b/app/Http/Controllers/Frontend/SoftwareFrontController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Frontend;
 
 use App\Http\Controllers\Controller;
+use App\Models\PageSetting;
 use App\Models\Software;
 use App\Models\SoftwareCategory;
 use Illuminate\Http\Request;
@@ -22,7 +23,10 @@ class SoftwareFrontController extends Controller
             })
             ->paginate(6);
 
-        return view('frontend.softwares.index', ['softwares' => $softwares, 'software_categories' => $software_categories]);
+        $softwaresPage = PageSetting::where('page_name', 'softwares')->first();
+        $softwaresSettings = $softwaresPage ? $softwaresPage->settings : [];
+
+        return view('frontend.softwares.index', ['softwares' => $softwares, 'software_categories' => $software_categories, 'softwaresSettings' => $softwaresSettings]);
     }
 
     public function show(Software $software)
@@ -30,7 +34,9 @@ class SoftwareFrontController extends Controller
         $software->load('software_category', 'keyFeatures', 'technologies', 'pricePlans.features');
         $softwares = Software::with('software_category')->limit(5)->get();
         $groupedPricePlans = $software->pricePlans->groupBy('type');
+        $softwareDetailPage = PageSetting::where('page_name', 'software-detail')->first();
+        $softwareDetailSettings = $softwareDetailPage ? $softwareDetailPage->settings : [];
 
-        return view('frontend.softwares.show', ['softwares' => $softwares, 'software' => $software, 'groupedPricePlans' => $groupedPricePlans]);
+        return view('frontend.softwares.show', ['softwares' => $softwares, 'software' => $software, 'groupedPricePlans' => $groupedPricePlans, 'softwareDetailSettings' => $softwareDetailSettings]);
     }
 }

--- a/app/Models/PageSetting.php
+++ b/app/Models/PageSetting.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class PageSetting extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'page_name',
+        'settings',
+    ];
+
+    protected $casts = [
+        'settings' => 'json',
+    ];
+}

--- a/database/migrations/2025_10_27_084653_create_page_settings_table.php
+++ b/database/migrations/2025_10_27_084653_create_page_settings_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('page_settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('page_name')->unique();
+            $table->json('settings');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('page_settings');
+    }
+};

--- a/resources/views/admin/layouts/app.blade.php
+++ b/resources/views/admin/layouts/app.blade.php
@@ -40,6 +40,28 @@
                     <a href="{{ route('admin.working-processes.index') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Working Processes</a>
                     <a href="{{ route('admin.values.index') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Values</a>
                     <a href="{{ route('admin.social-media-links.index') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Social Media Links</a>
+                    <hr class="my-2 border-gray-600">
+                    <a href="{{ route('admin.pages.home') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Home Page</a>
+                    <a href="{{ route('admin.pages.about') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">About Page</a>
+                    <a href="{{ route('admin.pages.contact') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Contact Page</a>
+                    <a href="{{ route('admin.pages.404') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">404 Page</a>
+                    <a href="{{ route('admin.pages.terms') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Terms & Conditions</a>
+                    <a href="{{ route('admin.pages.privacy') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Privacy Policy</a>
+                    <a href="{{ route('admin.pages.services') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Services Page</a>
+                    <a href="{{ route('admin.pages.articles') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Articles Page</a>
+                    <a href="{{ route('admin.pages.softwares') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Software Page</a>
+                    <a href="{{ route('admin.pages.projects') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Projects Page</a>
+                    <a href="{{ route('admin.pages.all-softwares') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">All Software Page</a>
+                    <a href="{{ route('admin.pages.custom-software') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Custom Software Page</a>
+                    <a href="{{ route('admin.pages.lets-discuss') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Let's Discuss Page</a>
+                    <a href="{{ route('admin.pages.thank-you') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Thank You Page</a>
+                    <a href="{{ route('admin.pages.service-plans') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Service Plans Page</a>
+                    <a href="{{ route('admin.pages.software-plans') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Software Plans Page</a>
+                    <a href="{{ route('admin.pages.careers') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Careers Page</a>
+                    <a href="{{ route('admin.pages.service-detail') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Service Detail Page</a>
+                    <a href="{{ route('admin.pages.article-detail') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Article Detail Page</a>
+                    <a href="{{ route('admin.pages.software-detail') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Software Detail Page</a>
+                    <a href="{{ route('admin.pages.project-detail') }}" class="block px-4 py-2 text-gray-300 hover:bg-gray-700">Project Detail Page</a>
                 </div>
             </nav>
         </aside>

--- a/resources/views/admin/pages/404.blade.php
+++ b/resources/views/admin/pages/404.blade.php
@@ -1,0 +1,41 @@
+@extends('admin.layouts.app')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title">404 Page Settings</h3>
+                    </div>
+                    <div class="card-body">
+                        <form action="{{ route('admin.pages.404.update') }}" method="POST" enctype="multipart/form-data">
+                            @csrf
+                            <div class="form-group">
+                                <label for="page_title">Page Title</label>
+                                <input type="text" name="page_title" id="page_title" class="form-control" value="{{ $notFoundSettings['page_title'] ?? '' }}">
+                            </div>
+                            <hr>
+                            <div class="form-group">
+                                <label for="404_title">Title</label>
+                                <input type="text" name="404_title" id="404_title" class="form-control" value="{{ $notFoundSettings['404_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="404_description">Description</label>
+                                <textarea name="404_description" id="404_description" class="form-control" rows="5">{{ $notFoundSettings['404_description'] ?? '' }}</textarea>
+                            </div>
+                            <div class="form-group">
+                                <label for="404_image">Image</label>
+                                <input type="file" name="404_image" id="404_image" class="form-control">
+                                @if(isset($notFoundSettings['404_image']))
+                                    <img src="{{ asset('storage/' . $notFoundSettings['404_image']) }}" alt="404 Image" class="img-thumbnail mt-2" width="200">
+                                @endif
+                            </div>
+                            <button type="submit" class="btn btn-primary">Update Settings</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/pages/about.blade.php
+++ b/resources/views/admin/pages/about.blade.php
@@ -1,0 +1,152 @@
+@extends('admin.layouts.app')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title">About Us Page Settings</h3>
+                    </div>
+                    <div class="card-body">
+                        <form action="{{ route('admin.pages.about.update') }}" method="POST" enctype="multipart/form-data">
+                            @csrf
+                            <div class="form-group">
+                                <label for="page_title">Page Title</label>
+                                <input type="text" name="page_title" id="page_title" class="form-control" value="{{ $aboutSettings['page_title'] ?? '' }}">
+                            </div>
+                            <hr>
+                            <div class="form-group">
+                                <label for="about_us_title">Title</label>
+                                <input type="text" name="about_us_title" id="about_us_title" class="form-control" value="{{ $aboutSettings['about_us_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="about_us_description">Description</label>
+                                <textarea name="about_us_description" id="about_us_description" class="form-control" rows="5">{{ $aboutSettings['about_us_description'] ?? '' }}</textarea>
+                            </div>
+                            <div class="form-group">
+                                <label for="about_us_image">Image</label>
+                                <input type="file" name="about_us_image" id="about_us_image" class="form-control">
+                                @if(isset($aboutSettings['about_us_image']))
+                                    <img src="{{ asset('storage/' . $aboutSettings['about_us_image']) }}" alt="About Us Image" class="img-thumbnail mt-2" width="200">
+                                @endif
+                            </div>
+                            <hr>
+                            <h4>Achievements</h4>
+                            <div class="form-group">
+                                <label for="achievement_title">Achievement Title</label>
+                                <input type="text" name="achievement_title" id="achievement_title" class="form-control" value="{{ $aboutSettings['achievement_title'] ?? '' }}">
+                            </div>
+                             <div class="form-group">
+                                <label for="achievement_description">Achievement Description</label>
+                                <input type="text" name="achievement_description" id="achievement_description" class="form-control" value="{{ $aboutSettings['achievement_description'] ?? '' }}">
+                            </div>
+                            <div class="row">
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label for="achievement_one_title">Achievement 1 Title</label>
+                                        <input type="text" name="achievement_one_title" id="achievement_one_title" class="form-control" value="{{ $aboutSettings['achievement_one_title'] ?? '' }}">
+                                    </div>
+                                </div>
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label for="achievement_one_value">Achievement 1 Value</label>
+                                        <input type="text" name="achievement_one_value" id="achievement_one_value" class="form-control" value="{{ $aboutSettings['achievement_one_value'] ?? '' }}">
+                                    </div>
+                                </div>
+                            </div>
+                             <div class="row">
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label for="achievement_two_title">Achievement 2 Title</label>
+                                        <input type="text" name="achievement_two_title" id="achievement_two_title" class="form-control" value="{{ $aboutSettings['achievement_two_title'] ?? '' }}">
+                                    </div>
+                                </div>
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label for="achievement_two_value">Achievement 2 Value</label>
+                                        <input type="text" name="achievement_two_value" id="achievement_two_value" class="form-control" value="{{ $aboutSettings['achievement_two_value'] ?? '' }}">
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label for="achievement_three_title">Achievement 3 Title</label>
+                                        <input type="text" name="achievement_three_title" id="achievement_three_title" class="form-control" value="{{ $aboutSettings['achievement_three_title'] ?? '' }}">
+                                    </div>
+                                </div>
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label for="achievement_three_value">Achievement 3 Value</label>
+                                        <input type="text" name="achievement_three_value" id="achievement_three_value" class="form-control" value="{{ $aboutSettings['achievement_three_value'] ?? '' }}">
+                                    </div>
+                                </div>
+                            </div>
+                            <hr>
+                            <h4>Journey</h4>
+                            <div class="form-group">
+                                <label for="journey_title">Journey Title</label>
+                                <input type="text" name="journey_title" id="journey_title" class="form-control" value="{{ $aboutSettings['journey_title'] ?? '' }}">
+                            </div>
+                             <div class="form-group">
+                                <label for="journey_description">Journey Description</label>
+                                <input type="text" name="journey_description" id="journey_description" class="form-control" value="{{ $aboutSettings['journey_description'] ?? '' }}">
+                            </div>
+                            <div class="row">
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label for="journey_one_title">Journey 1 Title</label>
+                                        <input type="text" name="journey_one_title" id="journey_one_title" class="form-control" value="{{ $aboutSettings['journey_one_title'] ?? '' }}">
+                                    </div>
+                                </div>
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label for="journey_one_description">Journey 1 Description</label>
+                                        <input type="text" name="journey_one_description" id="journey_one_description" class="form-control" value="{{ $aboutSettings['journey_one_description'] ?? '' }}">
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label for="journey_two_title">Journey 2 Title</label>
+                                        <input type="text" name="journey_two_title" id="journey_two_title" class="form-control" value="{{ $aboutSettings['journey_two_title'] ?? '' }}">
+                                    </div>
+                                </div>
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label for="journey_two_description">Journey 2 Description</label>
+                                        <input type="text" name="journey_two_description" id="journey_two_description" class="form-control" value="{{ $aboutSettings['journey_two_description'] ?? '' }}">
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label for="journey_three_title">Journey 3 Title</label>
+                                        <input type="text" name="journey_three_title" id="journey_three_title" class="form-control" value="{{ $aboutSettings['journey_three_title'] ?? '' }}">
+                                    </div>
+                                </div>
+                                <div class="col-md-6">
+                                    <div class="form-group">
+                                        <label for="journey_three_description">Journey 3 Description</label>
+                                        <input type="text" name="journey_three_description" id="journey_three_description" class="form-control" value="{{ $aboutSettings['journey_three_description'] ?? '' }}">
+                                    </div>
+                                </div>
+                            </div>
+                             <hr>
+                            <h4>Our Team</h4>
+                             <div class="form-group">
+                                <label for="team_title">Team Title</label>
+                                <input type="text" name="team_title" id="team_title" class="form-control" value="{{ $aboutSettings['team_title'] ?? '' }}">
+                            </div>
+
+                            <button type="submit" class="btn btn-primary">Update Settings</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/pages/all-softwares.blade.php
+++ b/resources/views/admin/pages/all-softwares.blade.php
@@ -1,0 +1,37 @@
+@extends('admin.layouts.app')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title">All Software Page Settings</h3>
+                    </div>
+                    <div class="card-body">
+                        <form action="{{ route('admin.pages.all-softwares.update') }}" method="POST">
+                            @csrf
+                            <div class="form-group">
+                                <label for="page_title">Page Title</label>
+                                <input type="text" name="page_title" id="page_title" class="form-control" value="{{ $allSoftwaresSettings['page_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="title">Title</label>
+                                <input type="text" name="title" id="title" class="form-control" value="{{ $allSoftwaresSettings['title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="description">Description</label>
+                                <textarea name="description" id="description" class="form-control" rows="5">{{ $allSoftwaresSettings['description'] ?? '' }}</textarea>
+                            </div>
+                            <div class="form-group">
+                                <label for="section_title">Section Title</label>
+                                <input type="text" name="section_title" id="section_title" class="form-control" value="{{ $allSoftwaresSettings['section_title'] ?? '' }}">
+                            </div>
+                            <button type="submit" class="btn btn-primary">Update Settings</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/pages/article-detail.blade.php
+++ b/resources/views/admin/pages/article-detail.blade.php
@@ -1,0 +1,33 @@
+@extends('admin.layouts.app')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title">Article Detail Page Settings</h3>
+                    </div>
+                    <div class="card-body">
+                        <form action="{{ route('admin.pages.article-detail.update') }}" method="POST">
+                            @csrf
+                            <div class="form-group">
+                                <label for="page_title">Page Title</label>
+                                <input type="text" name="page_title" id="page_title" class="form-control" value="{{ $articleDetailSettings['page_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="other_articles_title">Other Articles Title</label>
+                                <input type="text" name="other_articles_title" id="other_articles_title" class="form-control" value="{{ $articleDetailSettings['other_articles_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="other_articles_description">Other Articles Description</label>
+                                <textarea name="other_articles_description" id="other_articles_description" class="form-control" rows="5">{{ $articleDetailSettings['other_articles_description'] ?? '' }}</textarea>
+                            </div>
+                            <button type="submit" class="btn btn-primary">Update Settings</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/pages/articles.blade.php
+++ b/resources/views/admin/pages/articles.blade.php
@@ -1,0 +1,33 @@
+@extends('admin.layouts.app')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title">Articles Page Settings</h3>
+                    </div>
+                    <div class="card-body">
+                        <form action="{{ route('admin.pages.articles.update') }}" method="POST">
+                            @csrf
+                            <div class="form-group">
+                                <label for="page_title">Page Title</label>
+                                <input type="text" name="page_title" id="page_title" class="form-control" value="{{ $articlesSettings['page_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="title">Title</label>
+                                <input type="text" name="title" id="title" class="form-control" value="{{ $articlesSettings['title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="description">Description</label>
+                                <textarea name="description" id="description" class="form-control" rows="5">{{ $articlesSettings['description'] ?? '' }}</textarea>
+                            </div>
+                            <button type="submit" class="btn btn-primary">Update Settings</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/pages/careers.blade.php
+++ b/resources/views/admin/pages/careers.blade.php
@@ -1,0 +1,29 @@
+@extends('admin.layouts.app')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title">Careers Page Settings</h3>
+                    </div>
+                    <div class="card-body">
+                        <form action="{{ route('admin.pages.careers.update') }}" method="POST">
+                            @csrf
+                            <div class="form-group">
+                                <label for="page_title">Page Title</label>
+                                <input type="text" name="page_title" id="page_title" class="form-control" value="{{ $careersSettings['page_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="title">Title</label>
+                                <input type="text" name="title" id="title" class="form-control" value="{{ $careersSettings['title'] ?? '' }}">
+                            </div>
+                            <button type="submit" class="btn btn-primary">Update Settings</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/pages/contact.blade.php
+++ b/resources/views/admin/pages/contact.blade.php
@@ -1,0 +1,50 @@
+@extends('admin.layouts.app')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title">Contact Page Settings</h3>
+                    </div>
+                    <div class="card-body">
+                        <form action="{{ route('admin.pages.contact.update') }}" method="POST">
+                            @csrf
+                            <div class="form-group">
+                                <label for="page_title">Page Title</label>
+                                <input type="text" name="page_title" id="page_title" class="form-control" value="{{ $contactSettings['page_title'] ?? '' }}">
+                            </div>
+                            <hr>
+                            <div class="form-group">
+                                <label for="contact_title">Title</label>
+                                <input type="text" name="contact_title" id="contact_title" class="form-control" value="{{ $contactSettings['contact_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="contact_description">Description</label>
+                                <textarea name="contact_description" id="contact_description" class="form-control" rows="5">{{ $contactSettings['contact_description'] ?? '' }}</textarea>
+                            </div>
+                            <div class="form-group">
+                                <label for="contact_email">Email</label>
+                                <input type="email" name="contact_email" id="contact_email" class="form-control" value="{{ $contactSettings['contact_email'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="contact_phone">Phone</label>
+                                <input type="text" name="contact_phone" id="contact_phone" class="form-control" value="{{ $contactSettings['contact_phone'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="contact_address">Address</label>
+                                <input type="text" name="contact_address" id="contact_address" class="form-control" value="{{ $contactSettings['contact_address'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="contact_map_iframe_url">Map Iframe URL</label>
+                                <textarea name="contact_map_iframe_url" id="contact_map_iframe_url" class="form-control" rows="5">{{ $contactSettings['contact_map_iframe_url'] ?? '' }}</textarea>
+                            </div>
+                            <button type="submit" class="btn btn-primary">Update Settings</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/pages/custom-software.blade.php
+++ b/resources/views/admin/pages/custom-software.blade.php
@@ -1,0 +1,61 @@
+@extends('admin.layouts.app')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title">Custom Software Page Settings</h3>
+                    </div>
+                    <div class="card-body">
+                        <form action="{{ route('admin.pages.custom-software.update') }}" method="POST">
+                            @csrf
+                            <div class="form-group">
+                                <label for="page_title">Page Title</label>
+                                <input type="text" name="page_title" id="page_title" class="form-control" value="{{ $customSoftwareSettings['page_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="title">Title</label>
+                                <input type="text" name="title" id="title" class="form-control" value="{{ $customSoftwareSettings['title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="description">Description</label>
+                                <textarea name="description" id="description" class="form-control" rows="5">{{ $customSoftwareSettings['description'] ?? '' }}</textarea>
+                            </div>
+                            <hr>
+                            <h4>Why Choose Custom Software Section</h4>
+                            <div class="form-group">
+                                <label for="why_choose_title">Title</label>
+                                <input type="text" name="why_choose_title" id="why_choose_title" class="form-control" value="{{ $customSoftwareSettings['why_choose_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="why_choose_description">Description</label>
+                                <textarea name="why_choose_description" id="why_choose_description" class="form-control" rows="5">{{ $customSoftwareSettings['why_choose_description'] ?? '' }}</textarea>
+                            </div>
+                             <hr>
+                            <h4>Software Key Features Section</h4>
+                             <div class="form-group">
+                                <label for="key_features_title">Title</label>
+                                <input type="text" name="key_features_title" id="key_features_title" class="form-control" value="{{ $customSoftwareSettings['key_features_title'] ?? '' }}">
+                            </div>
+                            <hr>
+                            <h4>Software Plans Section</h4>
+                            <div class="form-group">
+                                <label for="plans_title">Title</label>
+                                <input type="text" name="plans_title" id="plans_title" class="form-control" value="{{ $customSoftwareSettings['plans_title'] ?? '' }}">
+                            </div>
+                             <hr>
+                            <h4>Technologies Section</h4>
+                            <div class="form-group">
+                                <label for="technologies_title">Title</label>
+                                <input type="text" name="technologies_title" id="technologies_title" class="form-control" value="{{ $customSoftwareSettings['technologies_title'] ?? '' }}">
+                            </div>
+                            <button type="submit" class="btn btn-primary">Update Settings</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/pages/home.blade.php
+++ b/resources/views/admin/pages/home.blade.php
@@ -1,0 +1,167 @@
+@extends('admin.layouts.app')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title">Home Page Settings</h3>
+                    </div>
+                    <div class="card-body">
+                        <form action="{{ route('admin.pages.home.update') }}" method="POST" enctype="multipart/form-data">
+                            @csrf
+                            <div class="form-group">
+                                <label for="page_title">Page Title</label>
+                                <input type="text" name="page_title" id="page_title" class="form-control" value="{{ $homeSettings['page_title'] ?? '' }}">
+                            </div>
+                            <hr>
+                            <div class="form-group">
+                                <label for="hero_title">Hero Title</label>
+                                <input type="text" name="hero_title" id="hero_title" class="form-control" value="{{ $homeSettings['hero_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="hero_subtitle">Hero Subtitle</label>
+                                <input type="text" name="hero_subtitle" id="hero_subtitle" class="form-control" value="{{ $homeSettings['hero_subtitle'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="hero_button_text">Hero Button Text</label>
+                                <input type="text" name="hero_button_text" id="hero_button_text" class="form-control" value="{{ $homeSettings['hero_button_text'] ?? '' }}">
+                            </div>
+                            <hr>
+                            <h4>Hero Card Section</h4>
+                            <div class="form-group">
+                                <label for="hero_card_description">Description</label>
+                                <input type="text" name="hero_card_description" id="hero_card_description" class="form-control" value="{{ $homeSettings['hero_card_description'] ?? '' }}">
+                            </div>
+                            <div class="row">
+                                <div class="col-md-4">
+                                    <div class="form-group">
+                                        <label for="hero_card_one_title">Card 1 Title</label>
+                                        <input type="text" name="hero_card_one_title" id="hero_card_one_title" class="form-control" value="{{ $homeSettings['hero_card_one_title'] ?? '' }}">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="hero_card_one_value">Card 1 Value</label>
+                                        <input type="text" name="hero_card_one_value" id="hero_card_one_value" class="form-control" value="{{ $homeSettings['hero_card_one_value'] ?? '' }}">
+                                    </div>
+                                     <div class="form-group">
+                                        <label for="hero_card_one_description">Card 1 Description</label>
+                                        <input type="text" name="hero_card_one_description" id="hero_card_one_description" class="form-control" value="{{ $homeSettings['hero_card_one_description'] ?? '' }}">
+                                    </div>
+                                </div>
+                                <div class="col-md-4">
+                                    <div class="form-group">
+                                        <label for="hero_card_two_title">Card 2 Title</label>
+                                        <input type="text" name="hero_card_two_title" id="hero_card_two_title" class="form-control" value="{{ $homeSettings['hero_card_two_title'] ?? '' }}">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="hero_card_two_value">Card 2 Value</label>
+                                        <input type="text" name="hero_card_two_value" id="hero_card_two_value" class="form-control" value="{{ $homeSettings['hero_card_two_value'] ?? '' }}">
+                                    </div>
+                                     <div class="form-group">
+                                        <label for="hero_card_two_description">Card 2 Description</label>
+                                        <input type="text" name="hero_card_two_description" id="hero_card_two_description" class="form-control" value="{{ $homeSettings['hero_card_two_description'] ?? '' }}">
+                                    </div>
+                                </div>
+                                <div class="col-md-4">
+                                    <div class="form-group">
+                                        <label for="hero_card_three_title">Card 3 Title</label>
+                                        <input type="text" name="hero_card_three_title" id="hero_card_three_title" class="form-control" value="{{ $homeSettings['hero_card_three_title'] ?? '' }}">
+                                    </div>
+                                    <div class="form-group">
+                                        <label for="hero_card_three_value">Card 3 Value</label>
+                                        <input type="text" name="hero_card_three_value" id="hero_card_three_value" class="form-control" value="{{ $homeSettings['hero_card_three_value'] ?? '' }}">
+                                    </div>
+                                     <div class="form-group">
+                                        <label for="hero_card_three_description">Card 3 Description</label>
+                                        <input type="text" name="hero_card_three_description" id="hero_card_three_description" class="form-control" value="{{ $homeSettings['hero_card_three_description'] ?? '' }}">
+                                    </div>
+                                </div>
+                            </div>
+                            <hr>
+                             <div class="form-group">
+                                <label for="search_title">Search Title</label>
+                                <input type="text" name="search_title" id="search_title" class="form-control" value="{{ $homeSettings['search_title'] ?? '' }}">
+                            </div>
+                            <hr>
+                            <h4>Services Section</h4>
+                            <div class="form-group">
+                                <label for="services_title">Services Title</label>
+                                <input type="text" name="services_title" id="services_title" class="form-control" value="{{ $homeSettings['services_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="services_description">Services Description</label>
+                                <textarea name="services_description" id="services_description" class="form-control" rows="5">{{ $homeSettings['services_description'] ?? '' }}</textarea>
+                            </div>
+                             <hr>
+                            <h4>Software Section</h4>
+                            <div class="form-group">
+                                <label for="software_title">Software Title</label>
+                                <input type="text" name="software_title" id="software_title" class="form-control" value="{{ $homeSettings['software_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="software_description">Software Description</label>
+                                <textarea name="software_description" id="software_description" class="form-control" rows="5">{{ $homeSettings['software_description'] ?? '' }}</textarea>
+                            </div>
+                            <hr>
+                            <h4>Projects Section</h4>
+                            <div class="form-group">
+                                <label for="projects_title">Projects Title</label>
+                                <input type="text" name="projects_title" id="projects_title" class="form-control" value="{{ $homeSettings['projects_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="projects_description">Projects Description</label>
+                                <textarea name="projects_description" id="projects_description" class="form-control" rows="5">{{ $homeSettings['projects_description'] ?? '' }}</textarea>
+                            </div>
+                            <hr>
+                            <h4>Contact Section</h4>
+                             <div class="form-group">
+                                <label for="contact_title">Contact Title</label>
+                                <input type="text" name="contact_title" id="contact_title" class="form-control" value="{{ $homeSettings['contact_title'] ?? '' }}">
+                            </div>
+                            <hr>
+                            <h4>Client Reviews Section</h4>
+                             <div class="form-group">
+                                <label for="client_reviews_title">Client Reviews Title</label>
+                                <input type="text" name="client_reviews_title" id="client_reviews_title" class="form-control" value="{{ $homeSettings['client_reviews_title'] ?? '' }}">
+                            </div>
+                             <div class="form-group">
+                                <label for="client_reviews_description">Client Reviews Description</label>
+                                <input type="text" name="client_reviews_description" id="client_reviews_description" class="form-control" value="{{ $homeSettings['client_reviews_description'] ?? '' }}">
+                            </div>
+                            <hr>
+                            <h4>Values Section</h4>
+                            <div class="form-group">
+                                <label for="values_title">Title</label>
+                                <input type="text" name="values_title" id="values_title" class="form-control" value="{{ $homeSettings['values_title'] ?? '' }}">
+                            </div>
+                             <hr>
+                            <h4>Working Process Section</h4>
+                             <div class="form-group">
+                                <label for="working_process_title">Title</label>
+                                <input type="text" name="working_process_title" id="working_process_title" class="form-control" value="{{ $homeSettings['working_process_title'] ?? '' }}">
+                            </div>
+                             <hr>
+                            <h4>FAQ Section</h4>
+                            <div class="form-group">
+                                <label for="faq_title">Title</label>
+                                <input type="text" name="faq_title" id="faq_title" class="form-control" value="{{ $homeSettings['faq_title'] ?? '' }}">
+                            </div>
+                             <hr>
+                            <h4>Articles Section</h4>
+                             <div class="form-group">
+                                <label for="articles_title">Title</label>
+                                <input type="text" name="articles_title" id="articles_title" class="form-control" value="{{ $homeSettings['articles_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="articles_description">Description</label>
+                                <input type="text" name="articles_description" id="articles_description" class="form-control" value="{{ $homeSettings['articles_description'] ?? '' }}">
+                            </div>
+                            <button type="submit" class="btn btn-primary">Update Settings</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/pages/lets-discuss.blade.php
+++ b/resources/views/admin/pages/lets-discuss.blade.php
@@ -1,0 +1,33 @@
+@extends('admin.layouts.app')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title">Let's Discuss Page Settings</h3>
+                    </div>
+                    <div class="card-body">
+                        <form action="{{ route('admin.pages.lets-discuss.update') }}" method="POST">
+                            @csrf
+                            <div class="form-group">
+                                <label for="page_title">Page Title</label>
+                                <input type="text" name="page_title" id="page_title" class="form-control" value="{{ $letsDiscussSettings['page_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="title">Title</label>
+                                <input type="text" name="title" id="title" class="form-control" value="{{ $letsDiscussSettings['title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="subtitle">Subtitle</label>
+                                <input type="text" name="subtitle" id="subtitle" class="form-control" value="{{ $letsDiscussSettings['subtitle'] ?? '' }}">
+                            </div>
+                            <button type="submit" class="btn btn-primary">Update Settings</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/pages/privacy.blade.php
+++ b/resources/views/admin/pages/privacy.blade.php
@@ -1,0 +1,34 @@
+@extends('admin.layouts.app')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title">Privacy Policy Page Settings</h3>
+                    </div>
+                    <div class="card-body">
+                        <form action="{{ route('admin.pages.privacy.update') }}" method="POST">
+                            @csrf
+                            <div class="form-group">
+                                <label for="page_title">Page Title</label>
+                                <input type="text" name="page_title" id="page_title" class="form-control" value="{{ $privacySettings['page_title'] ?? '' }}">
+                            </div>
+                            <hr>
+                            <div class="form-group">
+                                <label for="privacy_title">Title</label>
+                                <input type="text" name="privacy_title" id="privacy_title" class="form-control" value="{{ $privacySettings['privacy_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="privacy_content">Content</label>
+                                <textarea name="privacy_content" id="privacy_content" class="form-control ckeditor" rows="10">{{ $privacySettings['privacy_content'] ?? '' }}</textarea>
+                            </div>
+                            <button type="submit" class="btn btn-primary">Update Settings</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/pages/project-detail.blade.php
+++ b/resources/views/admin/pages/project-detail.blade.php
@@ -1,0 +1,37 @@
+@extends('admin.layouts.app')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title">Project Detail Page Settings</h3>
+                    </div>
+                    <div class="card-body">
+                        <form action="{{ route('admin.pages.project-detail.update') }}" method="POST">
+                            @csrf
+                            <div class="form-group">
+                                <label for="page_title">Page Title</label>
+                                <input type="text" name="page_title" id="page_title" class="form-control" value="{{ $projectDetailSettings['page_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="client_reviews_title">Client Reviews Title</label>
+                                <input type="text" name="client_reviews_title" id="client_reviews_title" class="form-control" value="{{ $projectDetailSettings['client_reviews_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="other_projects_title">Other Projects Title</label>
+                                <input type="text" name="other_projects_title" id="other_projects_title" class="form-control" value="{{ $projectDetailSettings['other_projects_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="other_projects_description">Other Projects Description</label>
+                                <textarea name="other_projects_description" id="other_projects_description" class="form-control" rows="5">{{ $projectDetailSettings['other_projects_description'] ?? '' }}</textarea>
+                            </div>
+                            <button type="submit" class="btn btn-primary">Update Settings</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/pages/projects.blade.php
+++ b/resources/views/admin/pages/projects.blade.php
@@ -1,0 +1,33 @@
+@extends('admin.layouts.app')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title">Projects Page Settings</h3>
+                    </div>
+                    <div class="card-body">
+                        <form action="{{ route('admin.pages.projects.update') }}" method="POST">
+                            @csrf
+                            <div class="form-group">
+                                <label for="page_title">Page Title</label>
+                                <input type="text" name="page_title" id="page_title" class="form-control" value="{{ $projectsSettings['page_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="title">Title</label>
+                                <input type="text" name="title" id="title" class="form-control" value="{{ $projectsSettings['title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="description">Description</label>
+                                <textarea name="description" id="description" class="form-control" rows="5">{{ $projectsSettings['description'] ?? '' }}</textarea>
+                            </div>
+                            <button type="submit" class="btn btn-primary">Update Settings</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/pages/service-detail.blade.php
+++ b/resources/views/admin/pages/service-detail.blade.php
@@ -1,0 +1,37 @@
+@extends('admin.layouts.app')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title">Service Detail Page Settings</h3>
+                    </div>
+                    <div class="card-body">
+                        <form action="{{ route('admin.pages.service-detail.update') }}" method="POST">
+                            @csrf
+                            <div class="form-group">
+                                <label for="page_title">Page Title</label>
+                                <input type="text" name="page_title" id="page_title" class="form-control" value="{{ $serviceDetailSettings['page_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="key_features_title">Key Features Title</label>
+                                <input type="text" name="key_features_title" id="key_features_title" class="form-control" value="{{ $serviceDetailSettings['key_features_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="technologies_title">Technologies Title</label>
+                                <input type="text" name="technologies_title" id="technologies_title" class="form-control" value="{{ $serviceDetailSettings['technologies_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="service_plans_title">Service Plans Title</label>
+                                <input type="text" name="service_plans_title" id="service_plans_title" class="form-control" value="{{ $serviceDetailSettings['service_plans_title'] ?? '' }}">
+                            </div>
+                            <button type="submit" class="btn btn-primary">Update Settings</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/pages/service-plans.blade.php
+++ b/resources/views/admin/pages/service-plans.blade.php
@@ -1,0 +1,29 @@
+@extends('admin.layouts.app')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title">Service Plans Page Settings</h3>
+                    </div>
+                    <div class="card-body">
+                        <form action="{{ route('admin.pages.service-plans.update') }}" method="POST">
+                            @csrf
+                            <div class="form-group">
+                                <label for="page_title">Page Title</label>
+                                <input type="text" name="page_title" id="page_title" class="form-control" value="{{ $servicePlansSettings['page_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="title">Title</label>
+                                <input type="text" name="title" id="title" class="form-control" value="{{ $servicePlansSettings['title'] ?? '' }}">
+                            </div>
+                            <button type="submit" class="btn btn-primary">Update Settings</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/pages/services.blade.php
+++ b/resources/views/admin/pages/services.blade.php
@@ -1,0 +1,33 @@
+@extends('admin.layouts.app')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title">Services Page Settings</h3>
+                    </div>
+                    <div class="card-body">
+                        <form action="{{ route('admin.pages.services.update') }}" method="POST">
+                            @csrf
+                            <div class="form-group">
+                                <label for="page_title">Page Title</label>
+                                <input type="text" name="page_title" id="page_title" class="form-control" value="{{ $servicesSettings['page_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="title">Title</label>
+                                <input type="text" name="title" id="title" class="form-control" value="{{ $servicesSettings['title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="description">Description</label>
+                                <textarea name="description" id="description" class="form-control" rows="5">{{ $servicesSettings['description'] ?? '' }}</textarea>
+                            </div>
+                            <button type="submit" class="btn btn-primary">Update Settings</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/pages/software-detail.blade.php
+++ b/resources/views/admin/pages/software-detail.blade.php
@@ -1,0 +1,37 @@
+@extends('admin.layouts.app')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title">Software Detail Page Settings</h3>
+                    </div>
+                    <div class="card-body">
+                        <form action="{{ route('admin.pages.software-detail.update') }}" method="POST">
+                            @csrf
+                            <div class="form-group">
+                                <label for="page_title">Page Title</label>
+                                <input type="text" name="page_title" id="page_title" class="form-control" value="{{ $softwareDetailSettings['page_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="key_features_title">Key Features Title</label>
+                                <input type="text" name="key_features_title" id="key_features_title" class="form-control" value="{{ $softwareDetailSettings['key_features_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="technologies_title">Technologies Title</label>
+                                <input type="text" name="technologies_title" id="technologies_title" class="form-control" value="{{ $softwareDetailSettings['technologies_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="software_plans_title">Software Plans Title</label>
+                                <input type="text" name="software_plans_title" id="software_plans_title" class="form-control" value="{{ $softwareDetailSettings['software_plans_title'] ?? '' }}">
+                            </div>
+                            <button type="submit" class="btn btn-primary">Update Settings</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/pages/software-plans.blade.php
+++ b/resources/views/admin/pages/software-plans.blade.php
@@ -1,0 +1,29 @@
+@extends('admin.layouts.app')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title">Software Plans Page Settings</h3>
+                    </div>
+                    <div class="card-body">
+                        <form action="{{ route('admin.pages.software-plans.update') }}" method="POST">
+                            @csrf
+                            <div class="form-group">
+                                <label for="page_title">Page Title</label>
+                                <input type="text" name="page_title" id="page_title" class="form-control" value="{{ $softwarePlansSettings['page_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="title">Title</label>
+                                <input type="text" name="title" id="title" class="form-control" value="{{ $softwarePlansSettings['title'] ?? '' }}">
+                            </div>
+                            <button type="submit" class="btn btn-primary">Update Settings</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/pages/softwares.blade.php
+++ b/resources/views/admin/pages/softwares.blade.php
@@ -1,0 +1,33 @@
+@extends('admin.layouts.app')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title">Software Page Settings</h3>
+                    </div>
+                    <div class="card-body">
+                        <form action="{{ route('admin.pages.softwares.update') }}" method="POST">
+                            @csrf
+                            <div class="form-group">
+                                <label for="page_title">Page Title</label>
+                                <input type="text" name="page_title" id="page_title" class="form-control" value="{{ $softwaresSettings['page_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="title">Title</label>
+                                <input type="text" name="title" id="title" class="form-control" value="{{ $softwaresSettings['title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="description">Description</label>
+                                <textarea name="description" id="description" class="form-control" rows="5">{{ $softwaresSettings['description'] ?? '' }}</textarea>
+                            </div>
+                            <button type="submit" class="btn btn-primary">Update Settings</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/pages/terms.blade.php
+++ b/resources/views/admin/pages/terms.blade.php
@@ -1,0 +1,34 @@
+@extends('admin.layouts.app')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title">Terms & Conditions Page Settings</h3>
+                    </div>
+                    <div class="card-body">
+                        <form action="{{ route('admin.pages.terms.update') }}" method="POST">
+                            @csrf
+                            <div class="form-group">
+                                <label for="page_title">Page Title</label>
+                                <input type="text" name="page_title" id="page_title" class="form-control" value="{{ $termsSettings['page_title'] ?? '' }}">
+                            </div>
+                            <hr>
+                            <div class="form-group">
+                                <label for="terms_title">Title</label>
+                                <input type="text" name="terms_title" id="terms_title" class="form-control" value="{{ $termsSettings['terms_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="terms_content">Content</label>
+                                <textarea name="terms_content" id="terms_content" class="form-control ckeditor" rows="10">{{ $termsSettings['terms_content'] ?? '' }}</textarea>
+                            </div>
+                            <button type="submit" class="btn btn-primary">Update Settings</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/pages/thank-you.blade.php
+++ b/resources/views/admin/pages/thank-you.blade.php
@@ -1,0 +1,33 @@
+@extends('admin.layouts.app')
+
+@section('content')
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-12">
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title">Thank You Page Settings</h3>
+                    </div>
+                    <div class="card-body">
+                        <form action="{{ route('admin.pages.thank-you.update') }}" method="POST">
+                            @csrf
+                            <div class="form-group">
+                                <label for="page_title">Page Title</label>
+                                <input type="text" name="page_title" id="page_title" class="form-control" value="{{ $thankYouSettings['page_title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="title">Title</label>
+                                <input type="text" name="title" id="title" class="form-control" value="{{ $thankYouSettings['title'] ?? '' }}">
+                            </div>
+                            <div class="form-group">
+                                <label for="subtitle">Subtitle</label>
+                                <input type="text" name="subtitle" id="subtitle" class="form-control" value="{{ $thankYouSettings['subtitle'] ?? '' }}">
+                            </div>
+                            <button type="submit" class="btn btn-primary">Update Settings</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -1,11 +1,12 @@
 @extends('frontend.layouts.app')
-@section('title', 'Not-found')
+@section('title', $notFoundSettings['page_title'] ?? 'Not Found')
 
 @section('content')
     <div class="container">
         <div class="w-8/12 text-center m-auto pb-16 lg:pb-20">
-            <h1 class="heading-text-regular-large text-secondary-950 my-14 lg:my-20 "> Whoops, that page is gone. </h1>
-            <img class="w-full lg:w-10/12 m-auto  " src="{{ asset('upload/notfoundimg.png') }}" alt="">
+        <h1 class="heading-text-regular-large text-secondary-950 my-14 lg:my-20 ">{{ $notFoundSettings['404_title'] ?? '' }}</h1>
+        <p>{{ $notFoundSettings['404_description'] ?? '' }}</p>
+        <img class="w-full lg:w-10/12 m-auto  " src="{{ asset('storage/' . ($notFoundSettings['404_image'] ?? '')) }}" alt="">
         </div>
     </div>
 

--- a/resources/views/frontend/about.blade.php
+++ b/resources/views/frontend/about.blade.php
@@ -1,35 +1,34 @@
 @extends('frontend.layouts.app')
+@section('title', $aboutSettings['page_title'] ?? 'About Us')
 
 @section('content')
     <div class="container my-10 md:my-20">
         <div class="flex flex-col justify-center items-center gap-8 md:gap-10">
-            <h1 class="heading-text-regular-large text-secondary-950 text-center text-3xl md:text-5xl">Leading the Way in <span class="text-primary-600">Digital Solutions</span></h1>
-            <img src="{{ asset('upload/aboutus.png') }}" alt="" class="w-full md:w-10/12 lg:w-8/12">
+        <h1 class="heading-text-regular-large text-secondary-950 text-center text-3xl md:text-5xl">{{ $aboutSettings['about_us_title'] ?? '' }}</h1>
+            <img src="{{ asset('storage/' . ($aboutSettings['about_us_image'] ?? '')) }}" alt="" class="w-full md:w-10/12 lg:w-8/12">
             <p class="w-full md:w-10/12 lg:w-8/12 sub-title-large-regular text-secondary-900 text-center">
-                short story about we're company. Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s,
-                <br class="hidden md:block">
-                when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially changed.
+                {{ $aboutSettings['about_us_description'] ?? '' }}
             </p>
         </div>
 
         {{-- Our Achievements --}}
         <div class="my-10 md:my-15">
-            <h1 class="heading-text-regular-large text-secondary-950 text-center text-3xl md:text-5xl">Our Achievements</h1>
+            <h1 class="heading-text-regular-large text-secondary-950 text-center text-3xl md:text-5xl">{{ $aboutSettings['achievement_title'] ?? '' }}</h1>
             <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 justify-center gap-6 py-10 md:py-15">
                 <div class="flex items-center">
-                    <p class="body-text-regular-medium text-secondary-800">We specialize in digital solutions to help your business grow and thrive in the digital landscape.</p>
+                    <p class="body-text-regular-medium text-secondary-800">{{ $aboutSettings['achievement_description'] ?? '' }}</p>
                 </div>
                 <div class="hero-card">
-                    <h1 class="title-text-bold-medium text-secondary-900">95%</h1>
-                    <h2 class="sub-title-large-regular text-secondary-900">Client Satisfaction</h2>
+                    <h1 class="title-text-bold-medium text-secondary-900">{{ $aboutSettings['achievement_one_value'] ?? '' }}</h1>
+                    <h2 class="sub-title-large-regular text-secondary-900">{{ $aboutSettings['achievement_one_title'] ?? '' }}</h2>
                 </div>
                 <div class="hero-card">
-                    <h1 class="title-text-bold-medium text-secondary-900">80+</h1>
-                    <h2 class="sub-title-large-regular text-secondary-900">Projects Completed</h2>
+                    <h1 class="title-text-bold-medium text-secondary-900">{{ $aboutSettings['achievement_two_value'] ?? '' }}</h1>
+                    <h2 class="sub-title-large-regular text-secondary-900">{{ $aboutSettings['achievement_two_title'] ?? '' }}</h2>
                 </div>
                 <div class="hero-card">
-                    <h1 class="title-text-bold-medium text-secondary-900">17+</h1>
-                    <h2 class="sub-title-large-regular text-secondary-900">Industries Served</h2>
+                    <h1 class="title-text-bold-medium text-secondary-900">{{ $aboutSettings['achievement_three_value'] ?? '' }}</h1>
+                    <h2 class="sub-title-large-regular text-secondary-900">{{ $aboutSettings['achievement_three_title'] ?? '' }}</h2>
                 </div>
             </div>
         </div>
@@ -37,8 +36,8 @@
 
         {{-- Our Journey --}}
         <div class="my-10 md:my-15 flex flex-col justify-center items-center gap-8">
-            <h1 class="heading-text-regular-large text-secondary-950 text-center text-3xl md:text-5xl">Our Journey</h1>
-            <p class="w-full md:w-10/12 sub-title-large-regular text-secondary-900 text-center">Our story is one of passion, innovation, and relentless dedication to delivering exceptional digital solutions. From humble beginnings to a global presence, we have grown into a trusted name in website development, custom software solutions, UI/UX design, digital marketing, and IT services.</p>
+            <h1 class="heading-text-regular-large text-secondary-950 text-center text-3xl md:text-5xl">{{ $aboutSettings['journey_title'] ?? '' }}</h1>
+            <p class="w-full md:w-10/12 sub-title-large-regular text-secondary-900 text-center">{{ $aboutSettings['journey_description'] ?? '' }}</p>
             <div class="w-full md:w-10/12 lg:w-8/12 mt-8">
                 <div class="relative">
                     <div class="border-l-2 border-primary-600 absolute h-full top-0 left-1/2 -translate-x-1/2"></div>
@@ -47,8 +46,8 @@
                         <div class="flex items-center">
                             <div class="w-1/2 pr-8">
                                 <div class="p-6 bg-white rounded-lg border border-secondary-400">
-                                    <h2 class="title-text-bold-medium text-secondary-950">2018</h2>
-                                    <p class="body-text-regular-medium text-secondary-800 mt-2">Founded with a vision to revolutionize the digital landscape, our agency started its journey with a small team of passionate innovators.</p>
+                                    <h2 class="title-text-bold-medium text-secondary-950">{{ $aboutSettings['journey_one_title'] ?? '' }}</h2>
+                                    <p class="body-text-regular-medium text-secondary-800 mt-2">{{ $aboutSettings['journey_one_description'] ?? '' }}</p>
                                 </div>
                             </div>
                             <div class="w-6 h-6 bg-primary-600 rounded-full absolute left-1/2 -translate-x-1/2"></div>
@@ -60,8 +59,8 @@
                             <div class="w-6 h-6 bg-primary-600 rounded-full absolute left-1/2 -translate-x-1/2"></div>
                             <div class="w-1/2 pl-8">
                                 <div class="p-6 bg-white rounded-lg border border-secondary-400">
-                                    <h2 class="title-text-bold-medium text-secondary-950">2020</h2>
-                                    <p class="body-text-regular-medium text-secondary-800 mt-2">Expanded our services to include custom software development and UI/UX design, helping businesses create seamless digital experiences.</p>
+                                    <h2 class="title-text-bold-medium text-secondary-950">{{ $aboutSettings['journey_two_title'] ?? '' }}</h2>
+                                    <p class="body-text-regular-medium text-secondary-800 mt-2">{{ $aboutSettings['journey_two_description'] ?? '' }}</p>
                                 </div>
                             </div>
                         </div>
@@ -69,8 +68,8 @@
                         <div class="flex items-center">
                             <div class="w-1/2 pr-8">
                                 <div class="p-6 bg-white rounded-lg border border-secondary-400">
-                                    <h2 class="title-text-bold-medium text-secondary-950">2022</h2>
-                                    <p class="body-text-regular-medium text-secondary-800 mt-2">Achieved a global presence by serving clients from over 17 countries, delivering innovative solutions that drive success worldwide.</p>
+                                    <h2 class="title-text-bold-medium text-secondary-950">{{ $aboutSettings['journey_three_title'] ?? '' }}</h2>
+                                    <p class="body-text-regular-medium text-secondary-800 mt-2">{{ $aboutSettings['journey_three_description'] ?? '' }}</p>
                                 </div>
                             </div>
                             <div class="w-6 h-6 bg-primary-600 rounded-full absolute left-1/2 -translate-x-1/2"></div>
@@ -84,7 +83,7 @@
 
         {{-- Our Team --}}
         <div class="my-10 md:my-15 flex flex-col justify-center items-center gap-8">
-            <h1 class="heading-text-regular-large text-secondary-950 text-center text-3xl md:text-5xl">Our Team</h1>
+            <h1 class="heading-text-regular-large text-secondary-950 text-center text-3xl md:text-5xl">{{ $aboutSettings['team_title'] ?? '' }}</h1>
             <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mt-8">
                 @foreach ($teams as $team)
                     <div class="flex flex-col gap-4">

--- a/resources/views/frontend/all-softwares.blade.php
+++ b/resources/views/frontend/all-softwares.blade.php
@@ -1,15 +1,16 @@
 @extends('frontend.layouts.app')
-@section('title', 'All-Softwares')
+@section('title', $allSoftwaresSettings['page_title'] ?? 'All Softwares')
 
 @section('content')
     <div class="container mx-auto">
 
         <h1 class="heading-text-regular-large text-center mt-20">
-            We provide Ready-Made  <span class=" text-primary-600"> Software Solutions</span</h1>
+            {{ $allSoftwaresSettings['title'] ?? '' }}
+        </h1>
 
         <div class=" flex flex-col items-center my-8">
             <div class="w-8/12">
-                <p class=" body-text-regular-large text-secondary-800 text-wrap">Explore our pre-built software solutions designed to save time and deliver results. Each product is crafted to meet industry standards and can be customized to suit your business needs.</p>
+                <p class=" body-text-regular-large text-secondary-800 text-wrap">{{ $allSoftwaresSettings['description'] ?? '' }}</p>
             </div>
 
             <div class="my-20">
@@ -20,7 +21,7 @@
          {{-- All softwares  --}}
 
          <div class="my-15">
-            <h1 class=" heading-text-regular-medium text-center text-secondary-950 mt-15 mb-8"> Technologies in the System</h1>
+            <h1 class=" heading-text-regular-medium text-center text-secondary-950 mt-15 mb-8"> {{ $allSoftwaresSettings['section_title'] ?? '' }}</h1>
 
             <div class="grid md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-2 gap-8 justify-center items-center p-6">
                 <!-- Service Card -->

--- a/resources/views/frontend/articles/index.blade.php
+++ b/resources/views/frontend/articles/index.blade.php
@@ -1,10 +1,10 @@
 @extends('frontend.layouts.app')
-@section('title', 'Articles')
+@section('title', $articlesSettings['page_title'] ?? 'Articles')
 
 @section('content')
     <div class="container mx-auto">
         <h1 class="text-3xl md:text-[52px] font-medium leading-tight md:leading-[68px] text-center mt-5">
-            Explore our least <span class="text-primary-600">Ariticles</span>
+            {{ $articlesSettings['title'] ?? '' }}
         </h1>
         <!-- Search Form -->
         <form action="{{ route('articles.index') }}" method="GET" class="mt-8 md:mt-14">
@@ -45,8 +45,7 @@
         @if ($articles->count() != 0)
             <div class="w-full md:w-8/12 lg:w-6/12 mt-16 md:mt-20 flex justify-center mx-auto">
                 <p class="sub-title-medium-regular leading-8 text-secondary-800 text-center">
-                    where we share the latest trends, insights, and best practices in
-                    technology, digital transformation, and business solutions.
+                    {{ $articlesSettings['description'] ?? '' }}
                 </p>
             </div>
         @endif

--- a/resources/views/frontend/articles/show.blade.php
+++ b/resources/views/frontend/articles/show.blade.php
@@ -1,10 +1,7 @@
 @extends('frontend.layouts.app')
-@section('title', 'Article - ' . $article->title)
+@section('title', $articleDetailSettings['page_title'] ?? 'Article Details')
 
 @section('content')
-
-{{$article}}
-
     <div class="container ">
 
         <h2 class="w-full lg:w-8/12 heading-text-regular-large  text-secondary-950 mt-20">{{ $article->title }}</h2>
@@ -29,9 +26,9 @@
         {{-- Article Slider Section start ================================================== --}}
         <div class="slider-container mt-20 xl:mb-20 overflow-hidden">
             <div>
-                <h1 class="heading-text-regular-medium text-center text-secondary-900">Other Articles</h1>
+                <h1 class="heading-text-regular-medium text-center text-secondary-900">{{ $articleDetailSettings['other_articles_title'] ?? '' }}</h1>
                 <div class="flex justify-between my-8 gap-5">
-                    <p class="body-text-regular-medium text-secondary-800 w-full  md:w-1/2"> Stay informed with our expert insights! Explore articles on the latest trends, tips, and strategies in web design, digital marketing, and more. </p>
+                    <p class="body-text-regular-medium text-secondary-800 w-full  md:w-1/2"> {{ $articleDetailSettings['other_articles_description'] ?? '' }} </p>
                     <div class="button-group border-secondary-600">
                         <button class="prev-btn button-label w-9 px-3 py-2 border-secondary-600 text-secondary-600"> <i class="w-5 h-5 fa-solid fa-circle-chevron-left"></i> </button>
                         <button class="next-btn button-label w-9 px-3 py-2 border-secondary-600 text-secondary-600"> <i class="w-5 h-5 fa-solid fa-circle-chevron-right"></i> </button>

--- a/resources/views/frontend/careers/index.blade.php
+++ b/resources/views/frontend/careers/index.blade.php
@@ -1,9 +1,9 @@
 @extends('frontend.layouts.app')
-@section('title', 'Career')
+@section('title', $careersSettings['page_title'] ?? 'Careers')
 
 @section('content')
     <div class="container mx-auto">
-        <h1 class="heading-text-regular-large text-center mt-20">Join our team best Opportunity <span class=" text-primary-600"> Opportunity</span> </h1>
+        <h1 class="heading-text-regular-large text-center mt-20">{{ $careersSettings['title'] ?? '' }}</h1>
 
         <!-- search  -->
         <!-- Search Form -->

--- a/resources/views/frontend/contact.blade.php
+++ b/resources/views/frontend/contact.blade.php
@@ -1,4 +1,5 @@
 @extends('frontend.layouts.app')
+@section('title', $contactSettings['page_title'] ?? 'Contact Us')
 
 @section('content')
     <div class="bg-gray-100">
@@ -10,22 +11,29 @@
             @endif
             <div class="flex flex-wrap -mx-4">
                 <div class="w-full md:w-1/2 px-4 mb-8 md:mb-0">
-                    <h2 class="text-3xl font-bold mb-4">Contact us</h2>
+                    <h2 class="text-3xl font-bold mb-4">{{ $contactSettings['contact_title'] ?? '' }}</h2>
                     <p class="text-gray-600 mb-8">
-                        We're here to help. If you have any questions, please don't hesitate to reach out to us.
+                        {{ $contactSettings['contact_description'] ?? '' }}
                     </p>
                     <div class="flex items-center mb-4">
                         <i class="fas fa-phone-alt text-2xl text-gray-600 mr-4"></i>
                         <div>
                             <p class="font-bold">Phone</p>
-                            <p class="text-gray-600">+1 234 567 890</p>
+                            <p class="text-gray-600">{{ $contactSettings['contact_phone'] ?? '' }}</p>
                         </div>
                     </div>
                     <div class="flex items-center mb-4">
                         <i class="fas fa-envelope text-2xl text-gray-600 mr-4"></i>
                         <div>
                             <p class="font-bold">Email</p>
-                            <p class="text-gray-600">info@example.com</p>
+                            <p class="text-gray-600">{{ $contactSettings['contact_email'] ?? '' }}</p>
+                        </div>
+                    </div>
+                    <div class="flex items-center mb-4">
+                        <i class="fas fa-map-marker-alt text-2xl text-gray-600 mr-4"></i>
+                        <div>
+                            <p class="font-bold">Address</p>
+                            <p class="text-gray-600">{{ $contactSettings['contact_address'] ?? '' }}</p>
                         </div>
                     </div>
                     <div class="flex mt-8">
@@ -60,6 +68,12 @@
                     </div>
                 </div>
             </div>
+        </div>
+    </div>
+    <div class="container mx-auto py-12">
+        <h2 class="text-3xl font-bold mb-4 text-center">Our Location</h2>
+        <div class="w-full">
+            {!! $contactSettings['contact_map_iframe_url'] ?? '' !!}
         </div>
     </div>
 @endsection

--- a/resources/views/frontend/custom-software.blade.php
+++ b/resources/views/frontend/custom-software.blade.php
@@ -1,15 +1,15 @@
 @extends('frontend.layouts.app')
-@section('title', 'Softwares')
+@section('title', $customSoftwareSettings['page_title'] ?? 'Custom Software')
 
 @section('content')
     <div class="container mx-auto">
 
         <h1 class="heading-text-regular-large text-center mt-20">
-            Empowering Your Vision with Tailored Solutions</h1>
+            {{ $customSoftwareSettings['title'] ?? '' }}</h1>
 
         <div class=" flex flex-col items-center my-8">
             <div class="w-8/12">
-                <p class=" body-text-regular-large text-secondary-800 text-wrap text-center">Our custom software development services are designed to create solutions that align perfectly with your business objectives. Whether you need to enhance efficiency, improve customer experiences, or scale operations, we’re here to deliver.</p>
+                <p class=" body-text-regular-large text-secondary-800 text-wrap text-center">{{ $customSoftwareSettings['description'] ?? '' }}</p>
             </div>
 
             <div class="my-20">
@@ -21,9 +21,9 @@
 
          <div class="slider-container mt-15 mb-20 overflow-hidden">
             <div>
-                <h1 class="heading-text-regular-medium text-center text-secondary-900">Why Choose Custom Software?</h1>
+                <h1 class="heading-text-regular-medium text-center text-secondary-900">{{ $customSoftwareSettings['why_choose_title'] ?? '' }}</h1>
                 <div class="flex justify-between my-8 gap-5">
-                    <p class="body-text-regular-medium text-secondary-800 w-full  md:w-1/2"> Custom software empowers your business with the tools to succeed. Contact us today to discuss your vision and explore how we can make it a reality. </p>
+                    <p class="body-text-regular-medium text-secondary-800 w-full  md:w-1/2"> {{ $customSoftwareSettings['why_choose_description'] ?? '' }} </p>
                     <div class="button-group ">
                         <button class="prev-btn-article button-label w-9 px-3 py-2  border-secondary-600 text-secondary-600"> <i class="w-5 h-5 fa-solid fa-circle-chevron-left"></i> </button>
                         <button class="next-btn-article button-label w-9 px-3 py-2  border-secondary-600 text-secondary-600"> <i class="w-5 h-5 fa-solid fa-circle-chevron-right"></i> </button>
@@ -63,7 +63,7 @@
 
          {{-- Software key Features  --}}
          <div class="mt-15 mb-20">
-            <h1 class=" heading-text-regular-medium text-secondary-900 text-center">Software Key Features</h1>
+            <h1 class=" heading-text-regular-medium text-secondary-900 text-center">{{ $customSoftwareSettings['key_features_title'] ?? '' }}</h1>
 
             <div class="w-10/12">
 
@@ -136,7 +136,7 @@
 
         {{-- Software Plans  --}}
         <div>
-            <h1 class=" heading-text-regular-medium text-center text-secondary-950 my-15"> Custom Software Plans</h1>
+            <h1 class=" heading-text-regular-medium text-center text-secondary-950 my-15"> {{ $customSoftwareSettings['plans_title'] ?? '' }}</h1>
             <div class="flex items-center justify-center">
 
                 <div class="w-4/12 viewer-card bg-primary-600 ">
@@ -178,7 +178,7 @@
         {{-- Technologies in the system  --}}
 
         <div class="my-15">
-            <h1 class=" heading-text-regular-medium text-center text-secondary-950 mt-15 mb-8"> Technologies in the System</h1>
+            <h1 class=" heading-text-regular-medium text-center text-secondary-950 mt-15 mb-8"> {{ $customSoftwareSettings['technologies_title'] ?? '' }}</h1>
 
             <div class="grid grid-cols-3 gap-6 justify-center">
                 <div class="service-item">

--- a/resources/views/frontend/home.blade.php
+++ b/resources/views/frontend/home.blade.php
@@ -1,44 +1,38 @@
 @extends('frontend.layouts.app')
-@section('title', 'Home')
+@section('title', $homeSettings['page_title'] ?? 'Home')
 
 @section('content')
 
 <div class="container">
     <div class="text-center py-10 md:py-20">
-        <h1 class="heading-text-regular-large text-secondary-950 text-2xl md:text-4xl lg:text-5xl">Your idea make in
-            Realty</h1>
-        <h1 class="heading-text-regular-large text-secondary-950 text-2xl md:text-4xl lg:text-5xl">We provide <span
-                class="text-primary-600">Digital Marketing</span></h1>
+        <h1 class="heading-text-regular-large text-secondary-950 text-2xl md:text-4xl lg:text-5xl">{{ $homeSettings['hero_title'] ?? '' }}</h1>
+        <h1 class="heading-text-regular-large text-secondary-950 text-2xl md:text-4xl lg:text-5xl">{{ $homeSettings['hero_subtitle'] ?? '' }}</h1>
 
         <div class="flex justify-center items-center mt-8 md:mt-14">
-            <button class="button-label px-5 py-2 md:px-7 md:py-3 bg-primary-600 text-white label-text-bold-large">Get
-                started <span><i class="fa-solid fa-arrow-right"></i></span></button>
+            <button class="button-label px-5 py-2 md:px-7 md:py-3 bg-primary-600 text-white label-text-bold-large">{{ $homeSettings['hero_button_text'] ?? '' }}
+                <span><i class="fa-solid fa-arrow-right"></i></span></button>
         </div>
     </div>
 
     {{-- hero card --}}
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 justify-center gap-6 py-10 md:py-15">
         <div class="flex items-center">
-            <p class="body-text-regular-medium text-secondary-800">We specialize in digital solutions to help your
-                business grow and thrive in the digital landscape.</p>
+            <p class="body-text-regular-medium text-secondary-800">{{ $homeSettings['hero_card_description'] ?? '' }}</p>
         </div>
         <div class="hero-card">
-            <h1 class="title-text-bold-medium text-secondary-900">95%</h1>
-            <h2 class="sub-title-large-regular text-secondary-900">Satisfied Customers</h2>
-            <p class="body-text-regular-small text-secondary-800">We are committed to providing the best solutions to
-                build happy relationships with our customers.</p>
+            <h1 class="title-text-bold-medium text-secondary-900">{{ $homeSettings['hero_card_one_value'] ?? '' }}</h1>
+            <h2 class="sub-title-large-regular text-secondary-900">{{ $homeSettings['hero_card_one_title'] ?? '' }}</h2>
+            <p class="body-text-regular-small text-secondary-800">{{ $homeSettings['hero_card_one_description'] ?? '' }}</p>
         </div>
         <div class="hero-card">
-            <h1 class="title-text-bold-medium text-secondary-900">80+</h1>
-            <h2 class="sub-title-large-regular text-secondary-900">Projects Completed</h2>
-            <p class="body-text-regular-small text-secondary-800">We are committed to providing the best solutions to
-                build happy relationships with our customers.</p>
+            <h1 class="title-text-bold-medium text-secondary-900">{{ $homeSettings['hero_card_two_value'] ?? '' }}</h1>
+            <h2 class="sub-title-large-regular text-secondary-900">{{ $homeSettings['hero_card_two_title'] ?? '' }}</h2>
+            <p class="body-text-regular-small text-secondary-800">{{ $homeSettings['hero_card_two_description'] ?? '' }}</p>
         </div>
         <div class="hero-card">
-            <h1 class="title-text-bold-medium text-secondary-900">12+</h1>
-            <h2 class="sub-title-large-regular text-secondary-900">Services served</h2>
-            <p class="body-text-regular-small text-secondary-800">We are committed to providing the best solutions to
-                build happy relationships with our customers.</p>
+            <h1 class="title-text-bold-medium text-secondary-900">{{ $homeSettings['hero_card_three_value'] ?? '' }}</h1>
+            <h2 class="sub-title-large-regular text-secondary-900">{{ $homeSettings['hero_card_three_title'] ?? '' }}</h2>
+            <p class="body-text-regular-small text-secondary-800">{{ $homeSettings['hero_card_three_description'] ?? '' }}</p>
         </div>
     </div>
     {{-- hero card --}}
@@ -102,8 +96,7 @@
 
     {{-- Searching section start --}}
     <div class="pt-10 md:pt-15 pb-10 md:pb-20">
-        <h1 class="text-center heading-text-regular-medium text-secondary-900 text-2xl md:text-3xl">Find the Perfect
-            Service for Your Needs</h1>
+        <h1 class="text-center heading-text-regular-medium text-secondary-900 text-2xl md:text-3xl">{{ $homeSettings['search_title'] ?? '' }}</h1>
         <div
             class="flex flex-col sm:flex-row w-full sm:w-8/12 md:w-6/12 m-auto items-center mt-8 p-2 sm:p-4 gap-2 border border-secondary-400 rounded-lg">
             <input type="text" name="search" value="{{ request('search') }}"
@@ -120,41 +113,18 @@
 
     {{-- values we live by start --}}
     <div class="pt-10 md:pt-15 pb-10 md:pb-20">
-        <h1 class="text-center heading-text-regular-medium text-secondary-900 text-2xl md:text-3xl">Values we live by
+        <h1 class="text-center heading-text-regular-medium text-secondary-900 text-2xl md:text-3xl">{{ $homeSettings['values_title'] ?? '' }}
         </h1>
         <div class="grid grid-cols-1 sm:grid-cols-2 justify-center items-center flex-wrap gap-6 mt-8">
-            <div class="viewer-card">
-                <h1 class="title-text-bold-medium text-secondary-950">Building Trust</h1>
-                <hr class="w-full h-px bg-secondary-400 border-0">
-                <p class="body-text-regular-large text-secondary-800 text-justify">
-                    By embodying ethical business practices, we weave trustworthiness and integrity into every
-                    connection we forge. This commitment paves the way for enduring and rewarding partnerships.
-                </p>
-            </div>
-            <div class="viewer-card">
-                <h1 class="title-text-bold-medium text-secondary-950">Future-Forward Thinking</h1>
-                <hr class="w-full h-px bg-secondary-400 border-0">
-                <p class="body-text-regular-large text-secondary-800 text-justify">
-                    We embrace innovation and stay ahead of industry trends to deliver cutting-edge solutions that drive
-                    growth and secure a competitive edge for our clients.
-                </p>
-            </div>
-            <div class="viewer-card">
-                <h1 class="title-text-bold-medium text-secondary-950">Key to Client Success Matters</h1>
-                <hr class="w-full h-px bg-secondary-400 border-0">
-                <p class="body-text-regular-large text-secondary-800 text-justify">
-                    We are dedicated to our clients' success, working collaboratively to understand their unique needs
-                    and deliver tailored solutions that produce measurable results.
-                </p>
-            </div>
-            <div class="viewer-card">
-                <h1 class="title-text-bold-medium text-secondary-950">Sustainable Business</h1>
-                <hr class="w-full h-px bg-secondary-400 border-0">
-                <p class="body-text-regular-large text-secondary-800 text-justify">
-                    We are committed to sustainable practices that benefit our clients, our team, and the planet,
-                    ensuring long-term success and a positive impact on the world.
-                </p>
-            </div>
+            @foreach ($values as $value)
+                <div class="viewer-card">
+                    <h1 class="title-text-bold-medium text-secondary-950">{{ $value->title }}</h1>
+                    <hr class="w-full h-px bg-secondary-400 border-0">
+                    <p class="body-text-regular-large text-secondary-800 text-justify">
+                        {{ $value->description }}
+                    </p>
+                </div>
+            @endforeach
         </div>
         <div class="flex justify-center items-center mt-14">
             <button class="button-label px-7 py-3 bg-primary-600 text-white label-text-bold-large">Get started <span><i
@@ -290,11 +260,9 @@
 
     {{-- Our least projects start --}}
     <div class="slider-container mt-10 md:mt-15 mb-10 md:mb-20 overflow-hidden">
-        <h1 class="text-center heading-text-regular-medium text-2xl md:text-3xl">Our Least Projects</h1>
+        <h1 class="text-center heading-text-regular-medium text-2xl md:text-3xl">{{ $homeSettings['projects_title'] ?? '' }}</h1>
         <div class="flex flex-col md:flex-row justify-between my-8 gap-5">
-            <p class="body-text-regular-medium text-secondary-800 w-full md:w-1/2">Explore how we’ve helped businesses
-                achieve their goals with tailored digital solutions. Our latest projects highlight creativity, strategy,
-                and measurable success in action.</p>
+            <p class="body-text-regular-medium text-secondary-800 w-full md:w-1/2">{{ $homeSettings['projects_description'] ?? '' }}</p>
             <div class="button-group flex justify-center md:justify-end gap-4">
                 <button class="prev-btn-project button-label w-9 px-3 py-2 border-secondary-600 text-secondary-600"><i
                         class="w-5 h-5 fa-solid fa-circle-chevron-left"></i></button>
@@ -323,11 +291,9 @@
 
     {{-- our services --}}
     <div class="slider-container mt-10 md:mt-15 mb-10 md:mb-20 overflow-hidden">
-        <h1 class="text-center heading-text-regular-medium text-2xl md:text-3xl">Our Services</h1>
+        <h1 class="text-center heading-text-regular-medium text-2xl md:text-3xl">{{ $homeSettings['services_title'] ?? '' }}</h1>
         <div class="flex flex-col md:flex-row justify-between my-8 gap-5">
-            <p class="body-text-regular-medium text-secondary-800 w-full md:w-1/2">We offer a wide range of digital
-                solutions tailored to meet your business needs. We provide innovative and impactful services to help you
-                succeed in the digital age.</p>
+            <p class="body-text-regular-medium text-secondary-800 w-full md:w-1/2">{{ $homeSettings['services_description'] ?? '' }}</p>
             <div class="button-group flex justify-center md:justify-end gap-4">
                 <button class="prev-btn-service button-label w-9 px-3 py-2 border-secondary-600 text-secondary-600"><i
                         class="w-5 h-5 fa-solid fa-circle-chevron-left"></i></button>
@@ -365,11 +331,9 @@
 
 {{-- Software's Solution --}}
 <div class="slider-container mt-10 md:mt-15 mb-10 md:mb-20 overflow-hidden">
-    <h1 class="text-center heading-text-regular-medium text-2xl md:text-3xl">Software's Solution</h1>
+    <h1 class="text-center heading-text-regular-medium text-2xl md:text-3xl">{{ $homeSettings['software_title'] ?? '' }}</h1>
     <div class="flex flex-col md:flex-row justify-between my-8 gap-5">
-        <p class="body-text-regular-medium text-secondary-800 w-full md:w-1/2">Simplify your operations with our
-            ready-made software solutions designed to streamline workflows and improve efficiency. Each system is built
-            with cutting-edge technology.</p>
+        <p class="body-text-regular-medium text-secondary-800 w-full md:w-1/2">{{ $homeSettings['software_description'] ?? '' }}</p>
         <div class="button-group flex justify-center md:justify-end gap-4">
             <button class="prev-btn-software button-label w-9 px-3 py-2 border-secondary-600 text-secondary-600"><i
                     class="w-5 h-5 fa-solid fa-circle-chevron-left"></i></button>
@@ -407,56 +371,37 @@
 
 {{-- Working process start --}}
 <div class="mt-10 md:mt-15 mb-10 md:mb-20">
-    <h1 class="heading-text-regular-medium text-center text-secondary-900 text-2xl md:text-3xl">Working Process</h1>
+    <h1 class="heading-text-regular-medium text-center text-secondary-900 text-2xl md:text-3xl">{{ $homeSettings['working_process_title'] ?? '' }}</h1>
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8 mt-8">
-        <div class="working-process-card">
-            <div class="w-12 h-12 bg-primary-100 rounded-full flex justify-center items-center">
-                <span class="title-text-bold-medium text-primary-600">1</span>
+        @foreach ($working_processes as $process)
+            <div class="working-process-card">
+                <div class="w-12 h-12 bg-primary-100 rounded-full flex justify-center items-center">
+                    <span class="title-text-bold-medium text-primary-600">{{ $loop->iteration }}</span>
+                </div>
+                <h2 class="title-text-bold-medium text-secondary-950 mt-4">{{ $process->title }}</h2>
+                <p class="body-text-regular-medium text-secondary-600 mt-2">{{ $process->description }}</p>
             </div>
-            <h2 class="title-text-bold-medium text-secondary-950 mt-4">[Step 1]</h2>
-            <p class="body-text-regular-medium text-secondary-600 mt-2">Initial consult or project brief</p>
-        </div>
-        <div class="working-process-card">
-            <div class="w-12 h-12 bg-primary-100 rounded-full flex justify-center items-center">
-                <span class="title-text-bold-medium text-primary-600">2</span>
-            </div>
-            <h2 class="title-text-bold-medium text-secondary-950 mt-4">[Step 2]</h2>
-            <p class="body-text-regular-medium text-secondary-600 mt-2">Price estimation</p>
-        </div>
-        <div class="working-process-card">
-            <div class="w-12 h-12 bg-primary-100 rounded-full flex justify-center items-center">
-                <span class="title-text-bold-medium text-primary-600">3</span>
-            </div>
-            <h2 class="title-text-bold-medium text-secondary-950 mt-4">[Step 3]</h2>
-            <p class="body-text-regular-medium text-secondary-600 mt-2">Start online</p>
-        </div>
-        <div class="working-process-card">
-            <div class="w-12 h-12 bg-primary-100 rounded-full flex justify-center items-center">
-                <span class="title-text-bold-medium text-primary-600">4</span>
-            </div>
-            <h2 class="title-text-bold-medium text-secondary-950 mt-4">[Step 4]</h2>
-            <p class="body-text-regular-medium text-secondary-600 mt-2">Work together</p>
-        </div>
+        @endforeach
     </div>
 </div>
 {{-- Working process end --}}
 
 {{-- Contact us start --}}
 <div class="mt-10 md:mt-15 mb-10 md:mb-20">
-    <h1 class="heading-text-regular-medium text-center text-secondary-900 mb-8 text-2xl md:text-3xl">Contact Us</h1>
+    <h1 class="heading-text-regular-medium text-center text-secondary-900 mb-8 text-2xl md:text-3xl">{{ $homeSettings['contact_title'] ?? '' }}</h1>
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
         <div class="flex flex-col gap-6">
             <div>
                 <p class="body-text-regular-medium text-secondary-600">Email</p>
-                <p class="body-text-bold-large text-secondary-900">info@yeasin-arena.com</p>
+                <p class="body-text-bold-large text-secondary-900">{{ $contactSettings['contact_email'] ?? '' }}</p>
             </div>
             <div>
                 <p class="body-text-regular-medium text-secondary-600">Phone</p>
-                <p class="body-text-bold-large text-secondary-900">BD (880) 01961007253</p>
+                <p class="body-text-bold-large text-secondary-900">{{ $contactSettings['contact_phone'] ?? '' }}</p>
             </div>
             <div>
                 <p class="body-text-regular-medium text-secondary-600">Office location</p>
-                <p class="body-text-bold-large text-secondary-900">Ground Floor, Rupchaniane, Dhaka</p>
+                <p class="body-text-bold-large text-secondary-900">{{ $contactSettings['contact_address'] ?? '' }}</p>
             </div>
         </div>
         <div>
@@ -546,11 +491,9 @@
 
 {{-- Client Reviews start --}}
 <div class="slider-container mt-10 md:mt-20 mb-10 md:mb-20 overflow-hidden">
-    <h1 class="heading-text-regular-medium text-center text-secondary-900 text-2xl md:text-3xl">Client Reviews</h1>
+    <h1 class="heading-text-regular-medium text-center text-secondary-900 text-2xl md:text-3xl">{{ $homeSettings['client_reviews_title'] ?? '' }}</h1>
     <div class="flex flex-col md:flex-row justify-between my-8 gap-5">
-        <p class="body-text-regular-medium text-secondary-800 w-full md:w-1/2">Hear from our satisfied clients! Their
-            feedback highlights our commitment to delivering exceptional digital solutions that drive results and build
-            trust.</p>
+        <p class="body-text-regular-medium text-secondary-800 w-full md:w-1/2">{{ $homeSettings['client_reviews_description'] ?? '' }}</p>
         <div class="button-group flex justify-center md:justify-end gap-4">
             <button
                 class="prev-btn-client-reviews button-label w-9 px-3 py-2 border-secondary-600 text-secondary-600"><i
@@ -573,71 +516,34 @@
 
 {{-- FAQ start --}}
 <div class="mt-10 md:mt-15 mb-10 md:mb-20" x-data="{ open: 0 }">
-    <h1 class="heading-text-regular-medium text-center text-secondary-900 text-2xl md:text-3xl">FAQ's</h1>
+    <h1 class="heading-text-regular-medium text-center text-secondary-900 text-2xl md:text-3xl">{{ $homeSettings['faq_title'] ?? '' }}</h1>
     <div class="mt-8 space-y-4">
-        <div class="border border-secondary-400 rounded-lg">
-            <div class="flex justify-between items-center p-4 cursor-pointer" @click="open = (open === 1 ? 0 : 1)">
-                <h2 class="title-text-bold-medium text-secondary-950">What services does your agency provide?</h2>
-                <i class="fa-solid" :class="open === 1 ? 'fa-minus' : 'fa-plus'"></i>
+        @foreach ($faqs as $faq)
+            <div class="border border-secondary-400 rounded-lg">
+                <div class="flex justify-between items-center p-4 cursor-pointer" @click="open = (open === {{ $loop->iteration }} ? 0 : {{ $loop->iteration }})">
+                    <h2 class="title-text-bold-medium text-secondary-950">{{ $faq->question }}</h2>
+                    <i class="fa-solid" :class="open === {{ $loop->iteration }} ? 'fa-minus' : 'fa-plus'"></i>
+                </div>
+                <div x-show="open === {{ $loop->iteration }}" class="p-4 border-t border-secondary-400"
+                    x-transition:enter="transition ease-out duration-300"
+                    x-transition:enter-start="opacity-0 transform -translate-y-2"
+                    x-transition:enter-end="opacity-100 transform translate-y-0"
+                    x-transition:leave="transition ease-in duration-200"
+                    x-transition:leave-start="opacity-100 transform translate-y-0"
+                    x-transition:leave-end="opacity-0 transform -translate-y-2">
+                    <p class="body-text-regular-medium text-secondary-600">{{ $faq->answer }}</p>
+                </div>
             </div>
-            <div x-show="open === 1" class="p-4 border-t border-secondary-400"
-                x-transition:enter="transition ease-out duration-300"
-                x-transition:enter-start="opacity-0 transform -translate-y-2"
-                x-transition:enter-end="opacity-100 transform translate-y-0"
-                x-transition:leave="transition ease-in duration-200"
-                x-transition:leave-start="opacity-100 transform translate-y-0"
-                x-transition:leave-end="opacity-0 transform -translate-y-2">
-                <p class="body-text-regular-medium text-secondary-600">We offer a comprehensive range of digital
-                    services, including web design and development, mobile app development, UX/UI design, digital
-                    marketing, SEO, and more. Our goal is to provide end-to-end solutions to help your business thrive
-                    in the digital landscape.</p>
-            </div>
-        </div>
-        <div class="border border-secondary-400 rounded-lg">
-            <div class="flex justify-between items-center p-4 cursor-pointer" @click="open = (open === 2 ? 0 : 2)">
-                <h2 class="title-text-bold-medium text-secondary-950">What industries do you specialize in?</h2>
-                <i class="fa-solid" :class="open === 2 ? 'fa-minus' : 'fa-plus'"></i>
-            </div>
-            <div x-show="open === 2" class="p-4 border-t border-secondary-400"
-                x-transition:enter="transition ease-out duration-300"
-                x-transition:enter-start="opacity-0 transform -translate-y-2"
-                x-transition:enter-end="opacity-100 transform translate-y-0"
-                x-transition:leave="transition ease-in duration-200"
-                x-transition:leave-start="opacity-100 transform translate-y-0"
-                x-transition:leave-end="opacity-0 transform -translate-y-2">
-                <p class="body-text-regular-medium text-secondary-600">We have experience working with a diverse range
-                    of industries, including e-commerce, healthcare, education, and technology. Our team is adaptable
-                    and can tailor our services to meet the unique needs of your industry.</p>
-            </div>
-        </div>
-        <div class="border border-secondary-400 rounded-lg">
-            <div class="flex justify-between items-center p-4 cursor-pointer" @click="open = (open === 3 ? 0 : 3)">
-                <h2 class="title-text-bold-medium text-secondary-950">Do you provide support after project completion?
-                </h2>
-                <i class="fa-solid" :class="open === 3 ? 'fa-minus' : 'fa-plus'"></i>
-            </div>
-            <div x-show="open === 3" class="p-4 border-t border-secondary-400"
-                x-transition:enter="transition ease-out duration-300"
-                x-transition:enter-start="opacity-0 transform -translate-y-2"
-                x-transition:enter-end="opacity-100 transform translate-y-0"
-                x-transition:leave="transition ease-in duration-200"
-                x-transition:leave-start="opacity-100 transform translate-y-0"
-                x-transition:leave-end="opacity-0 transform -translate-y-2">
-                <p class="body-text-regular-medium text-secondary-600">Yes, we offer ongoing support and maintenance to
-                    ensure your website or application continues to run smoothly. We believe in building long-term
-                    partnerships with our clients and are always here to help with any future needs.</p>
-            </div>
-        </div>
+        @endforeach
     </div>
 </div>
 {{-- FAQ end --}}
 
 {{-- Articles start --}}
 <div class="slider-container mt-10 md:mt-15 mb-10 md:mb-20 overflow-hidden">
-    <h1 class="heading-text-regular-medium text-center text-secondary-900 text-2xl md:text-3xl">Articles</h1>
+    <h1 class="heading-text-regular-medium text-center text-secondary-900 text-2xl md:text-3xl">{{ $homeSettings['articles_title'] ?? '' }}</h1>
     <div class="flex flex-col md:flex-row justify-between my-8 gap-5">
-        <p class="body-text-regular-medium text-secondary-800 w-full md:w-1/2">Stay informed with our expert insights!
-            Explore articles on the latest trends, tips, and strategies in web design, digital marketing, and more.</p>
+        <p class="body-text-regular-medium text-secondary-800 w-full md:w-1/2">{{ $homeSettings['articles_description'] ?? '' }}</p>
         <div class="button-group flex justify-center md:justify-end gap-4">
             <button class="prev-btn-article button-label w-9 px-3 py-2 border-secondary-600 text-secondary-600"><i
                     class="w-5 h-5 fa-solid fa-circle-chevron-left"></i></button>

--- a/resources/views/frontend/lets-discuss.blade.php
+++ b/resources/views/frontend/lets-discuss.blade.php
@@ -1,11 +1,11 @@
 @extends('frontend.layouts.app')
-@section('title', 'lets-discuss')
+@section('title', $letsDiscussSettings['page_title'] ?? 'Let\'s Discuss')
 
 @section('content')
     <div class="container">
         <div class="w-8/12 text-center m-auto pt-20">
-            <h1 class="heading-text-bold-large text-secondary-950">Let's discuss with US</h1>
-            <p class="sub-title-medium-regular text-secondary-600 pt-8">Get your information so we can contact you</p>
+            <h1 class="heading-text-bold-large text-secondary-950">{{ $letsDiscussSettings['title'] ?? '' }}</h1>
+            <p class="sub-title-medium-regular text-secondary-600 pt-8">{{ $letsDiscussSettings['subtitle'] ?? '' }}</p>
         </div>
 
         <form action="" method="POST">

--- a/resources/views/frontend/privacy-policy.blade.php
+++ b/resources/views/frontend/privacy-policy.blade.php
@@ -1,131 +1,13 @@
 @extends('frontend.layouts.app')
-@section('title', 'Terms-conditions')
+@section('title', $privacySettings['page_title'] ?? 'Privacy Policy')
 
 @section('content')
     <div class="container">
-        <div class="w-8/12 text-center m-auto pt-20">
-            <h1 class="heading-text-bold-large text-secondary-950">Privacy Policy</h1>
-            <p class="sub-title-medium-regular text-secondary-600 pt-8">Your privacy is our priority. This Privacy Policy explains how we collect, use, and protect your data when using [Your Company Name]'s website and services.
-            </p>
-
-            <div class=" mt-14">
-                <p class="text-left body-text-regular-large  text-secondary-800 ">1.1 Introduction</p>
-                <p class="text-left body-text-regular-large  text-secondary-800 ">Your privacy is our priority. This Privacy Policy explains how we collect, use, and protect your data when using [Your Company Name]'s website and services.</p>
+        <div class="w-full md:w-8/12 m-auto pt-20 max-md:px-4">
+            <h1 class="heading-text-bold-large text-secondary-950 text-center">{{ $privacySettings['privacy_title'] ?? '' }}</h1>
+            <div class="prose lg:prose-xl max-w-none mt-8">
+                {!! $privacySettings['privacy_content'] ?? '' !!}
             </div>
-            <div class=" mt-4  ">
-                <p class="text-left body-text-regular-large text-secondary-800 ">2.2 Information We Collect</p>
-                <p class="text-left body-text-regular-large text-secondary-800 ">. Personal Information</p>
-                <ul class="  text-left list-disc   space-y-1 body-text-regular-large text-secondary-800  ml-8 ">
-                    <li class="text-left  ">Name, email address, phone number, billing details.</li>
-                    <li class="text-left ">Payment details (handled securely by third-party providers).</li>
-
-                </ul>
-
-            </div>
-            <div class=" mt-4  ">
-                <p class="text-left body-text-regular-large text-secondary-800 ">B. Non-Personal Data</p>
-                <ul class=" text-left list-disc   space-y-1 body-text-regular-large text-secondary-800  ml-8">
-                    <li class=" ">IP address, browser type, and device information.</li>
-                    <li class=" ">Website activity logs and usage patterns.</li>
-
-                </ul>
-            </div>
-            <div class=" mt-4  ">
-                <p class="text-left body-text-regular-large text-secondary-800 ">2.3 How We Use Your Information</p>
-                <p class="text-left body-text-regular-large text-secondary-800 ">Your data is used for the following purposes: </p>
-                <ul class="  text-left list-disc   space-y-1 body-text-regular-large text-secondary-800  ml-8">
-                    <li class=" ">To provide services: Process orders, subscriptions, and customer support requests.</li>
-                    <li class=" ">To improve user experience: Analyze website performance and optimize content.</li>
-
-                    <li class="">To enhance security: Prevent fraud and unauthorized access.</li>
-                </ul>
-            </div>
-            <div class=" mt-4  ">
-
-                <p class="text-left body-text-regular-large text-secondary-800 ">2.4 Data Protection & Security </p>
-                <ul class="  text-left list-disc   space-y-1 body-text-regular-large text-secondary-800  ml-8 ">
-                    <li class=" ">We use SSL encryption and firewall protection to safeguard your data.</li>
-                    <li class=" ">User passwords are hashed and securely stored.</li>
-                    <li class="">While we take strict measures, no system is 100% secure from cyber threats..</li>
-
-                </ul>
-            </div>
-            <div class=" mt-4  ">
-
-                <p class="text-left body-text-regular-large text-secondary-800 ">2.5 Sharing Your Data</p>
-                <p class="text-left body-text-regular-large text-secondary-800 ">We do not sell or rent your personal data. However, we may share your information with:</p>
-                <ul class="  text-left list-disc   space-y-1 body-text-regular-large text-secondary-800  ml-8">
-                    <li class=" ">Trusted third-party vendors for payment processing.</li>
-                    <li class=" ">Legal authorities when required by law.</li>
-                    <li class="">Business partners (with your consent) for joint marketing efforts.</li>
-
-                </ul>
-            </div>
-            <div class=" mt-4  ">
-                <p class="text-left body-text-regular-large text-secondary-800 ">2.6 Cookies and Tracking Technologies</p>
-                <ul class=" text-left list-disc   space-y-1 body-text-regular-large text-secondary-800  ml-8">
-                    <li class=" ">We use cookies to improve user experience and track analytics.</li>
-                    <li class=" ">Users may not use, copy, distribute, or modify any proprietary material without written permission.</li>
-                    <li class="">UUsers can disable cookies via their browser settings.</li>
-
-                </ul>
-            </div>
-            <div class=" mt-4  ">
-                <p class="text-left body-text-regular-large text-secondary-800 ">2.7 Third-Party Links </p>
-
-                <p class="text-left body-text-regular-large text-secondary-800 ">Our website may contain links to third-party websites. We are not responsible for their privacy practices or content. </p>
-
-            </div>
-            <div class=" mt-4  ">
-                <p class="text-left body-text-regular-large text-secondary-800 ">2.8 Your Rights & Choices </p>
-                <ul class=" text-left list-disc   space-y-1 body-text-regular-large text-secondary-800  ml-8">
-                    <li class=" ">Users can update, modify, or delete their personal data at any time.</li>
-                    <li class=" ">You can opt out of marketing emails via the unsubscribe link in our emails.</li>
-                    <li class="">You have the right to request a copy of the data we store about you.</li>
-
-                </ul>
-            </div>
-            <div class=" mt-4  ">
-                <p class="text-left body-text-regular-large text-secondary-800 ">2.9 Data Retention Policy </p>
-                <ul class=" text-left list-disc   space-y-1 body-text-regular-large text-secondary-800  ml-8 ">
-                    <li class=" ">We retain user data for as long as necessary to fulfill legal and business obligations.</li>
-                    <li class=" ">Inactive accounts may have their data deleted after 12 months.</li>
-
-                </ul>
-            </div>
-            <div class=" mt-4  ">
-                <p class="text-left body-text-regular-large text-secondary-800 ">2.10 Changes to Privacy Policy</p>
-                <p class="text-left body-text-regular-large text-secondary-800 ">We reserve the right to update this Privacy Policy as needed. Continued use of our services after policy changes means you accept the new terms. </p>
-
-            </div>
-
-
-        </div>
-
-
-        <div class="w-8/12 text-center m-auto pt-20">
-            <h1 class="heading-text-regular-large text-secondary-950">Contact Information</h1>
-            <p class="sub-title-medium-regular text-secondary-600 pt-8">If you have any questions about our Terms and Conditions or Privacy Policy, please contact us.
-            </p>
-
-            <form action="">
-                <div class="flex w-[808px] flex-col p-6 gap-6 border border-secondary-400 rounded-2xl m-auto mt-8 mb-20">
-                    <div class="flex gap-2 flex-col"><label class="inpul-label text-left" for="">Your name</label><input
-                        type="text" name="" id="" placeholder="e.g Jhon brgke value="">
-                   </div>
-                    <div class="flex gap-2 flex-col"><label class="inpul-label text-left" for="">Your e-mail</label><input
-                        type="email" name="" id="" placeholder="e.g. jhonrgeke@gmail.com" value="">
-                   </div>
-
-                    <div class="flex gap-2 flex-col"><label class="input-label text-left" for="">Your question</label>
-                        <textarea rows="3" name="" id="" placeholder="Write your answer here"></textarea>
-                    </div>
-
-                    <hr class="h-px  bg-secondary-400 border-0 ">
-                    <button class="btn-outline-full">Submit  </button>
-
-                </div>
-            </form>
         </div>
     </div>
 

--- a/resources/views/frontend/projects/index.blade.php
+++ b/resources/views/frontend/projects/index.blade.php
@@ -1,10 +1,10 @@
 @extends('frontend.layouts.app')
-@section('title', 'Projects')
+@section('title', $projectsSettings['page_title'] ?? 'Projects')
 
 @section('content')
     <div class="container mx-auto">
         <h1 class="text-3xl md:text-[52px] font-medium leading-tight md:leading-[68px] text-center mt-5">
-            Explore our least <span class="text-primary-600">Projects</span>
+            {{ $projectsSettings['title'] ?? '' }}
         </h1>
         <!-- Search Form -->
         <form action="{{ route('projects') }}" method="GET" class="mt-8 md:mt-14">
@@ -45,8 +45,7 @@
         @if ($projects->count() != 0)
             <div class="w-full md:w-8/12 lg:w-6/12 mt-16 md:mt-20 flex justify-center mx-auto">
                 <p class="sub-title-medium-regular leading-8 text-secondary-800 text-center">
-                    where we share the latest trends, insights, and best practices in
-                    technology, digital transformation, and business solutions.
+                    {{ $projectsSettings['description'] ?? '' }}
                 </p>
             </div>
         @endif

--- a/resources/views/frontend/projects/show.blade.php
+++ b/resources/views/frontend/projects/show.blade.php
@@ -1,5 +1,5 @@
 @extends('frontend.layouts.app')
-@section('title', 'project - ' . $project->title)
+@section('title', $projectDetailSettings['page_title'] ?? 'Project Details')
 
 @section('content')
 
@@ -53,7 +53,7 @@
 
 
         <div class="mt-20 xl:mb-20 overflow-hidden">
-            <h1 class="heading-text-regular-medium text-center text-secondary-900">Client Reviews</h1>
+            <h1 class="heading-text-regular-medium text-center text-secondary-900">{{ $projectDetailSettings['client_reviews_title'] ?? '' }}</h1>
             <div class="w-1/2 mt-8 mx-auto">
                 <x-frontend.client-review :review="$project->clientReview" />
             </div>
@@ -66,9 +66,9 @@
         {{-- project Slider Section start ================================================== --}}
         <div class="slider-container mt-20 xl:mb-20 overflow-hidden">
             <div>
-                <h1 class="heading-text-regular-medium text-center text-secondary-900">Other projects</h1>
+                <h1 class="heading-text-regular-medium text-center text-secondary-900">{{ $projectDetailSettings['other_projects_title'] ?? '' }}</h1>
                 <div class="flex justify-between my-8 gap-5">
-                    <p class="body-text-regular-medium text-secondary-800 w-full  md:w-1/2"> Stay informed with our expert insights! Explore projects on the latest trends, tips, and strategies in web design, digital marketing, and more. </p>
+                    <p class="body-text-regular-medium text-secondary-800 w-full  md:w-1/2"> {{ $projectDetailSettings['other_projects_description'] ?? '' }} </p>
                     <div class="button-group border-secondary-600">
                         <button class="prev-btn button-label w-9 px-3 py-2 border-secondary-600 text-secondary-600"> <i class="w-5 h-5 fa-solid fa-circle-chevron-left"></i> </button>
                         <button class="next-btn button-label w-9 px-3 py-2 border-secondary-600 text-secondary-600"> <i class="w-5 h-5 fa-solid fa-circle-chevron-right"></i> </button>

--- a/resources/views/frontend/service-plans.blade.php
+++ b/resources/views/frontend/service-plans.blade.php
@@ -1,8 +1,9 @@
 @extends('frontend.layouts.app')
+@section('title', $servicePlansSettings['page_title'] ?? 'Service Plans')
 
 @section('content')
     <div class="container mx-auto px-4 py-8">
-        <h1 class="text-3xl font-bold text-center mb-8">Service Plans</h1>
+        <h1 class="text-3xl font-bold text-center mb-8">{{ $servicePlansSettings['title'] ?? '' }}</h1>
 
         <div x-data="{ activeTab: {{ $serviceCategories->first()->id }} }">
             <div class="flex justify-center mb-8">

--- a/resources/views/frontend/services/index.blade.php
+++ b/resources/views/frontend/services/index.blade.php
@@ -1,10 +1,10 @@
 @extends('frontend.layouts.app')
-@section('title', 'Services')
+@section('title', $servicesSettings['page_title'] ?? 'Services')
 
 @section('content')
     <div class="container mx-auto">
         <h1 class="text-3xl md:text-[52px] font-medium leading-tight md:leading-[68px] text-center mt-5">
-            Explore our least <span class="text-primary-600">Services</span>
+            {{ $servicesSettings['title'] ?? '' }}
         </h1>
         <!-- Search Form -->
         <form action="{{ route('services') }}" method="GET" class="mt-8 md:mt-14">
@@ -45,8 +45,7 @@
         @if ($services->count() != 0)
             <div class="w-full md:w-8/12 lg:w-6/12 mt-16 md:mt-20 flex justify-center mx-auto">
                 <p class="sub-title-medium-regular leading-8 text-secondary-800 text-center">
-                    where we share the latest trends, insights, and best practices in
-                    technology, digital transformation, and business solutions.
+                    {{ $servicesSettings['description'] ?? '' }}
                 </p>
             </div>
         @endif

--- a/resources/views/frontend/services/show.blade.php
+++ b/resources/views/frontend/services/show.blade.php
@@ -1,5 +1,5 @@
 @extends('frontend.layouts.app')
-@section('title', 'Service - ' . $service->name)
+@section('title', $serviceDetailSettings['page_title'] ?? 'Service Details')
 
 @section('content')
     <div class="container ">
@@ -13,7 +13,7 @@
 
         {{-- Key Features Section --}}
         <div class="my-20" x-data="{ activeTab: 0 }">
-            <h2 class="heading-text-regular-medium text-center text-secondary-900 mb-8">Key Features</h2>
+            <h2 class="heading-text-regular-medium text-center text-secondary-900 mb-8">{{ $serviceDetailSettings['key_features_title'] ?? '' }}</h2>
             <div class="flex justify-center mb-8">
                 @foreach ($service->keyFeatures as $key => $keyFeature)
                     <button @click="activeTab = {{ $key }}"
@@ -30,7 +30,7 @@
 
         {{-- Technologies Section --}}
         <div class="my-20">
-            <h2 class="heading-text-regular-medium text-center text-secondary-900 mb-8">Technologies We Use</h2>
+            <h2 class="heading-text-regular-medium text-center text-secondary-900 mb-8">{{ $serviceDetailSettings['technologies_title'] ?? '' }}</h2>
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
                 @foreach ($service->technologies as $technology)
                     <div class="card">
@@ -46,7 +46,7 @@
 
         {{-- Service Plans Section --}}
         <div class="my-20" x-data="{ activeTab: 0 }">
-            <h2 class="heading-text-regular-medium text-center text-secondary-900 mb-8">Service Plans</h2>
+            <h2 class="heading-text-regular-medium text-center text-secondary-900 mb-8">{{ $serviceDetailSettings['service_plans_title'] ?? '' }}</h2>
             <div class="flex justify-center mb-8">
                 @foreach ($service->serviceTypes as $key => $serviceType)
                     <button @click="activeTab = {{ $key }}"

--- a/resources/views/frontend/software-plans.blade.php
+++ b/resources/views/frontend/software-plans.blade.php
@@ -1,8 +1,9 @@
 @extends('frontend.layouts.app')
+@section('title', $softwarePlansSettings['page_title'] ?? 'Software Plans')
 
 @section('content')
     <div class="container mx-auto px-4 py-8">
-        <h1 class="text-3xl font-bold text-center mb-8">Software Plans</h1>
+        <h1 class="text-3xl font-bold text-center mb-8">{{ $softwarePlansSettings['title'] ?? '' }}</h1>
 
         <div x-data="{ activeTab: {{ $softwareCategories->first()->id }} }">
             <div class="flex justify-center mb-8">

--- a/resources/views/frontend/softwares/index.blade.php
+++ b/resources/views/frontend/softwares/index.blade.php
@@ -1,10 +1,10 @@
 @extends('frontend.layouts.app')
-@section('title', 'Softwares')
+@section('title', $softwaresSettings['page_title'] ?? 'Softwares')
 
 @section('content')
     <div class="container mx-auto">
         <h1 class="text-3xl md:text-[52px] font-medium leading-tight md:leading-[68px] text-center mt-5">
-            Explore our least <span class="text-primary-600">Softwares</span>
+            {{ $softwaresSettings['title'] ?? '' }}
         </h1>
         <!-- Search Form -->
         <form action="{{ route('softwares') }}" method="GET" class="mt-8 md:mt-14">
@@ -45,8 +45,7 @@
         @if ($softwares->count() != 0)
             <div class="w-full md:w-8/12 lg:w-6/12 mt-16 md:mt-20 flex justify-center mx-auto">
                 <p class="sub-title-medium-regular leading-8 text-secondary-800 text-center">
-                    where we share the latest trends, insights, and best practices in
-                    technology, digital transformation, and business solutions.
+                    {{ $softwaresSettings['description'] ?? '' }}
                 </p>
             </div>
         @endif

--- a/resources/views/frontend/softwares/show.blade.php
+++ b/resources/views/frontend/softwares/show.blade.php
@@ -1,5 +1,5 @@
 @extends('frontend.layouts.app')
-@section('title', 'Software - ' . $software->name)
+@section('title', $softwareDetailSettings['page_title'] ?? 'Software Details')
 
 @section('content')
     <div class="container ">
@@ -13,7 +13,7 @@
 
         {{-- Key Features Section --}}
         <div class="my-20" x-data="{ activeTab: 0 }">
-            <h2 class="heading-text-regular-medium text-center text-secondary-900 mb-8">Key Features</h2>
+            <h2 class="heading-text-regular-medium text-center text-secondary-900 mb-8">{{ $softwareDetailSettings['key_features_title'] ?? '' }}</h2>
             <div class="flex justify-center mb-8">
                 @foreach ($software->keyFeatures as $key => $keyFeature)
                     <button @click="activeTab = {{ $key }}"
@@ -30,7 +30,7 @@
 
         {{-- Technologies Section --}}
         <div class="my-20">
-            <h2 class="heading-text-regular-medium text-center text-secondary-900 mb-8">Technologies We Use</h2>
+            <h2 class="heading-text-regular-medium text-center text-secondary-900 mb-8">{{ $softwareDetailSettings['technologies_title'] ?? '' }}</h2>
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
                 @foreach ($software->technologies as $technology)
                     <div class="card">
@@ -46,7 +46,7 @@
 
         {{-- Software Plans Section --}}
         <div class="my-20" x-data="{ activeTab: 0 }">
-            <h2 class="heading-text-regular-medium text-center text-secondary-900 mb-8">Software Plans</h2>
+            <h2 class="heading-text-regular-medium text-center text-secondary-900 mb-8">{{ $softwareDetailSettings['software_plans_title'] ?? '' }}</h2>
             <div class="flex justify-center mb-8">
                 @foreach ($groupedPricePlans as $type => $plans)
                     <button @click="activeTab = {{ $loop->index }}"

--- a/resources/views/frontend/terms-conditions.blade.php
+++ b/resources/views/frontend/terms-conditions.blade.php
@@ -1,120 +1,14 @@
 @extends('frontend.layouts.app')
-@section('title', 'Terms-conditions')
+@section('title', $termsSettings['page_title'] ?? 'Terms & Conditions')
 
 @section('content')
     <div class="container">
-        <div class="w-full md:w-8/12 text-center m-auto pt-20 max-md:px-4">
-            <h1 class="heading-text-bold-large text-secondary-950">Terms and Conditions</h1>
-            <p class="sub-title-medium-regular text-secondary-600 pt-8">These Terms and Conditions ("Terms") govern your access to and use of [Your Company Name]'s website, software, and services. By using our platform, you agree to follow these terms and
-                abide by all applicable laws and regulations. If you do not agree with these terms, please do not use our services.
-            </p>
-
-            <div class=" mt-14">
-                <p class="text-left body-text-regular-large  text-secondary-800 ">1.1 Introduction</p>
-                <p class="text-left body-text-regular-large  text-secondary-800 ">These Terms and Conditions ("Terms") govern your access to and use of [Your Company Name]'s website, software, and services. By using our platform, you agree to follow these
-                    terms and abide by all applicable laws and regulations. If you do not agree with these terms, please do not use our services.</p>
+        <div class="w-full md:w-8/12 m-auto pt-20 max-md:px-4">
+            <h1 class="heading-text-bold-large text-secondary-950 text-center">{{ $termsSettings['terms_title'] ?? '' }}</h1>
+            <div class="prose lg:prose-xl max-w-none mt-8">
+                {!! $termsSettings['terms_content'] ?? '' !!}
             </div>
-            <div class=" mt-4  ">
-                <p class="text-left body-text-regular-large text-secondary-800 ">1.2 Eligibility</p>
-                <p class="text-left body-text-regular-large text-secondary-800 ">To use our services, you must: </p>
-                <ul class=" text-left list-disc   space-y-1 body-text-regular-large text-secondary-800  ml-8">
-                    <li class="text-left  ">Be at least 18 years old (or meet the minimum legal age in your jurisdiction).</li>
-                    <li class="text-left ">Provide accurate and truthful information when registering an account..</li>
-                    <li class="text-left ">Not use our services for any illegal or unauthorized activities.</li>
-
-                </ul>
-
-                <p class="text-left body-text-regular-large text-secondary-800 ">We reserve the right to suspend or terminate your account if we find that you are in violation of these conditions.</p>
-
-            </div>
-            <div class=" mt-4  ">
-                <p class="text-left body-text-regular-large text-secondary-800 ">1.3 Use of Our Services</p>
-                <p class="text-left body-text-regular-large text-secondary-800 ">By using [Your Company Name], you agree to: </p>
-                <ul class="  text-left list-disc space-y-1 body-text-regular-large text-secondary-800  ml-8 ">
-                    <li class=" ">Use our services for lawful purposes only.</li>
-                    <li class=" ">Not modify, distribute, copy, or reproduce any content from our platform without permission.</li>
-                    <li class="">Not attempt to gain unauthorized access to our systems or user accounts.</li>
-                    <li class="">Not use our services for spamming, hacking, or fraudulent activities.</li>
-
-                </ul>
-            </div>
-            <div class=" mt-4  ">
-                <p class="text-left body-text-regular-large text-secondary-800 ">1.4 Payment, Subscription & Refund Policy</p>
-                <p class="text-left body-text-regular-large text-secondary-800 ">A. Payment Terms </p>
-                <ul class="  text-left list-disc   space-y-1 body-text-regular-large text-secondary-800  ml-8 ">
-                    <li class=" ">Payments must be made in full before accessing premium features or software.</li>
-                    <li class=" ">We accept payments via credit cards, PayPal, and direct bank transfers.</li>
-                    <li class="">Failure to complete payments may result in temporary or permanent account suspension.</li>
-
-                </ul>
-            </div>
-            <div class=" mt-4  ">
-
-                <p class="text-left body-text-regular-large text-secondary-800 ">B. Subscription Plans </p>
-                <ul class="  text-left list-disc   space-y-1 body-text-regular-large text-secondary-800  ml-8">
-                    <li class=" ">We offer monthly, quarterly, and annual subscription plans for our services.</li>
-                    <li class=" ">We accept payments via credit cards, PayPal, and direct bank transfers.</li>
-                    <li class="">Your subscription will automatically renew unless you cancel it before the renewal date.</li>
-
-                </ul>
-            </div>
-            <div class=" mt-4  ">
-
-                <p class="text-left body-text-regular-large text-secondary-800 ">C. Refund Policy </p>
-                <ul class=" text-left list-disc   space-y-1 body-text-regular-large text-secondary-800  ml-8">
-                    <li class=" ">Refunds must be requested within 7 days of purchase.</li>
-                    <li class=" ">We reserve the right to deny refunds for services that have already been utilized.</li>
-                    <li class="">Custom software and development services are non-refundable once work has begun.</li>
-
-                </ul>
-            </div>
-            <div class=" mt-4  ">
-                <p class="text-left body-text-regular-large text-secondary-800 ">1.5 Intellectual Property Rights </p>
-                <ul class="  text-left list-disc   space-y-1 body-text-regular-large text-secondary-800  ml-8  ">
-                    <li class=" ">All content, including logos, text, graphics, software, and source code, belongs to [Your Company Name].</li>
-                    <li class=" ">Users may not use, copy, distribute, or modify any proprietary material without written permission.</li>
-                    <li class="">Unauthorized use of our intellectual property may result in legal action.</li>
-
-                </ul>
-            </div>
-            <div class=" mt-4  ">
-                <p class="text-left body-text-regular-large text-secondary-800 ">1.6 Intellectual Property Rights </p>
-                <ul class="  text-left list-disc   space-y-1 body-text-regular-large text-secondary-800  ml-8  ">
-                    <li class=" ">All content, including logos, text, graphics, software, and source code, belongs to [Your Company Name].</li>
-                    <li class=" ">Users may not use, copy, distribute, or modify any proprietary material without written permission.</li>
-                    <li class="">Unauthorized use of our intellectual property may result in legal action.</li>
-
-                </ul>
-            </div>
-            <div class=" mt-4  ">
-                <p class="text-left body-text-regular-large text-secondary-800 ">1.7 Intellectual Property Rights </p>
-                <ul class="  text-left list-disc   space-y-1 body-text-regular-large text-secondary-800  ml-8 ">
-                    <li class=" ">All content, including logos, text, graphics, software, and source code, belongs to [Your Company Name].</li>
-                    <li class=" ">Users may not use, copy, distribute, or modify any proprietary material without written permission.</li>
-                    <li class="">Unauthorized use of our intellectual property may result in legal action.</li>
-
-                </ul>
-            </div>
-            <div class=" mt-4  ">
-                <p class="text-left body-text-regular-large text-secondary-800 ">1.8 Intellectual Property Rights </p>
-                <ul class="  text-left list-disc   space-y-1 body-text-regular-large text-secondary-800  ml-8 ">
-                    <li class=" ">All content, including logos, text, graphics, software, and source code, belongs to [Your Company Name].</li>
-                    <li class=" ">Users may not use, copy, distribute, or modify any proprietary material without written permission.</li>
-                    <li class="">Unauthorized use of our intellectual property may result in legal action.</li>
-
-                </ul>
-            </div>
-            <div class=" mt-4  ">
-                <p class="text-left body-text-regular-large text-secondary-800 ">1.9 Changes to Terms</p>
-                <p class="text-left body-text-regular-large text-secondary-800 ">We may update these Terms and Conditions at any time. Continued use of our services after changes means you accept the updated terms. </p>
-
-            </div>
-
-
         </div>
-
-
-
     </div>
 
 @endsection

--- a/resources/views/frontend/thank-you-page.blade.php
+++ b/resources/views/frontend/thank-you-page.blade.php
@@ -1,15 +1,15 @@
 @extends('frontend.layouts.app')
-@section('title', 'Thank-you')
+@section('title', $thankYouSettings['page_title'] ?? 'Thank You')
 
 @section('content')
     <div class="container">
         <div class="w-8/12 text-center m-auto pt-20 mb-[80px]">
 
             <img class="w-[184px] h-[184px]  mx-auto " src="{{ asset('upload/mail-heart.svg') }}" alt="">
-            <h1 class="heading-text-bold-large text-secondary-950 mt-7">Thanks for Your Enquiry </h1>
+            <h1 class="heading-text-bold-large text-secondary-950 mt-7">{{ $thankYouSettings['title'] ?? '' }}</h1>
 
             <p class="title-text-regular-x-large text-secondary-600 ">
-                We will respond to you within 24 hours
+                {{ $thankYouSettings['subtitle'] ?? '' }}
             </p>
         </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,6 +26,7 @@ use App\Http\Controllers\Admin\VacancyController;
 use App\Http\Controllers\Admin\TechnologyController;
 use App\Http\Controllers\Admin\KeyFeatureController;
 use App\Http\Controllers\Admin\FeatureController;
+use App\Http\Controllers\Admin\PageSettingController;
 
 Route::get('/', function () {
     return view('welcome');
@@ -81,6 +82,11 @@ Route::resource('careers', CareerFrontController::class)->only(['index', 'show']
 Route::get('/careers/apply/{slug}', [CareerFrontController::class, 'apply'])->name('careers.apply');
 Route::post('/careers/apply/{slug}', [CareerFrontController::class, 'apply_submit'])->name('careers.apply.submit');
 
+Route::fallback(function () {
+    $notFoundPage = \App\Models\PageSetting::where('page_name', '404')->first();
+    $notFoundSettings = $notFoundPage ? $notFoundPage->settings : [];
+    return response()->view('errors.404', compact('notFoundSettings'), 404);
+});
 
 Route::name('admin.')->prefix('admin')->middleware(['auth'])->group(function () {
     Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard.index');
@@ -106,6 +112,49 @@ Route::name('admin.')->prefix('admin')->middleware(['auth'])->group(function () 
     Route::resource('social-media-links', \App\Http\Controllers\Admin\SocialMediaLinkController::class);
     Route::resource('service-types', \App\Http\Controllers\Admin\ServiceTypeController::class);
     Route::resource('price-plans', \App\Http\Controllers\Admin\PricePlanController::class);
+
+    Route::get('pages/about', [PageSettingController::class, 'about'])->name('pages.about');
+    Route::post('pages/about', [PageSettingController::class, 'aboutUpdate'])->name('pages.about.update');
+    Route::get('pages/home', [PageSettingController::class, 'home'])->name('pages.home');
+    Route::post('pages/home', [PageSettingController::class, 'homeUpdate'])->name('pages.home.update');
+    Route::get('pages/contact', [PageSettingController::class, 'contact'])->name('pages.contact');
+    Route::post('pages/contact', [PageSettingController::class, 'contactUpdate'])->name('pages.contact.update');
+    Route::get('pages/404', [PageSettingController::class, 'notFound'])->name('pages.404');
+    Route::post('pages/404', [PageSettingController::class, 'notFoundUpdate'])->name('pages.404.update');
+    Route::get('pages/terms', [PageSettingController::class, 'terms'])->name('pages.terms');
+    Route::post('pages/terms', [PageSettingController::class, 'termsUpdate'])->name('pages.terms.update');
+    Route::get('pages/privacy', [PageSettingController::class, 'privacy'])->name('pages.privacy');
+    Route::post('pages/privacy', [PageSettingController::class, 'privacyUpdate'])->name('pages.privacy.update');
+    Route::get('pages/services', [PageSettingController::class, 'services'])->name('pages.services');
+    Route::post('pages/services', [PageSettingController::class, 'servicesUpdate'])->name('pages.services.update');
+    Route::get('pages/articles', [PageSettingController::class, 'articles'])->name('pages.articles');
+    Route::post('pages/articles', [PageSettingController::class, 'articlesUpdate'])->name('pages.articles.update');
+    Route::get('pages/softwares', [PageSettingController::class, 'softwares'])->name('pages.softwares');
+    Route::post('pages/softwares', [PageSettingController::class, 'softwaresUpdate'])->name('pages.softwares.update');
+    Route::get('pages/projects', [PageSettingController::class, 'projects'])->name('pages.projects');
+    Route::post('pages/projects', [PageSettingController::class, 'projectsUpdate'])->name('pages.projects.update');
+    Route::get('pages/all-softwares', [PageSettingController::class, 'allSoftwares'])->name('pages.all-softwares');
+    Route::post('pages/all-softwares', [PageSettingController::class, 'allSoftwaresUpdate'])->name('pages.all-softwares.update');
+    Route::get('pages/custom-software', [PageSettingController::class, 'customSoftware'])->name('pages.custom-software');
+    Route::post('pages/custom-software', [PageSettingController::class, 'customSoftwareUpdate'])->name('pages.custom-software.update');
+    Route::get('pages/lets-discuss', [PageSettingController::class, 'letsDiscuss'])->name('pages.lets-discuss');
+    Route::post('pages/lets-discuss', [PageSettingController::class, 'letsDiscussUpdate'])->name('pages.lets-discuss.update');
+    Route::get('pages/thank-you', [PageSettingController::class, 'thankYou'])->name('pages.thank-you');
+    Route::post('pages/thank-you', [PageSettingController::class, 'thankYouUpdate'])->name('pages.thank-you.update');
+    Route::get('pages/service-plans', [PageSettingController::class, 'servicePlans'])->name('pages.service-plans');
+    Route::post('pages/service-plans', [PageSettingController::class, 'servicePlansUpdate'])->name('pages.service-plans.update');
+    Route::get('pages/software-plans', [PageSettingController::class, 'softwarePlans'])->name('pages.software-plans');
+    Route::post('pages/software-plans', [PageSettingController::class, 'softwarePlansUpdate'])->name('pages.software-plans.update');
+    Route::get('pages/careers', [PageSettingController::class, 'careers'])->name('pages.careers');
+    Route::post('pages/careers', [PageSettingController::class, 'careersUpdate'])->name('pages.careers.update');
+    Route::get('pages/service-detail', [PageSettingController::class, 'serviceDetail'])->name('pages.service-detail');
+    Route::post('pages/service-detail', [PageSettingController::class, 'serviceDetailUpdate'])->name('pages.service-detail.update');
+    Route::get('pages/article-detail', [PageSettingController::class, 'articleDetail'])->name('pages.article-detail');
+    Route::post('pages/article-detail', [PageSettingController::class, 'articleDetailUpdate'])->name('pages.article-detail.update');
+    Route::get('pages/software-detail', [PageSettingController::class, 'softwareDetail'])->name('pages.software-detail');
+    Route::post('pages/software-detail', [PageSettingController::class, 'softwareDetailUpdate'])->name('pages.software-detail.update');
+    Route::get('pages/project-detail', [PageSettingController::class, 'projectDetail'])->name('pages.project-detail');
+    Route::post('pages/project-detail', [PageSettingController::class, 'projectDetailUpdate'])->name('pages.project-detail.update');
 });
 
 


### PR DESCRIPTION
This commit introduces a comprehensive system for managing page content dynamically through the admin panel.

Key changes include:
- Created a `PageSetting` model and `page_settings` table to store page-specific content in a flexible JSON format.
- Implemented an `Admin\PageSettingController` with a full suite of admin views to manage content for nearly 20 pages, including the homepage, about page, contact page, service/article/project/software index and detail pages, and the 404 page.
- Refactored the `PageSettingController` to use a reusable private method, significantly reducing code duplication.
- Updated all relevant frontend controllers and Blade views to fetch and render the dynamic content.
- Ensured all page titles (`<title>` tag) are now dynamic and editable from the admin panel.
- Fixed a potential XSS vulnerability by replacing unescaped Blade tags with escaped ones for all plain text content.
- Added a dynamic Google Maps iframe to the contact page, manageable from the admin settings.