### PR TITLE
feat: Make business and trusted partners dynamic

### DIFF
--- a/app/Http/Controllers/Frontend/HomeController.php
+++ b/app/Http/Controllers/Frontend/HomeController.php
@@ -10,6 +10,8 @@ use App\Models\PageSetting;
 use App\Models\Project;
 use App\Models\Service;
 use App\Models\Software;
+use App\Models\BusinessPartner;
+use App\Models\TrustedPartner;
 use App\Models\Value;
 use App\Models\WorkingProcess;
 
@@ -25,6 +27,8 @@ class HomeController extends Controller
         $values = Value::latest()->limit(4)->get();
         $working_processes = WorkingProcess::latest()->limit(4)->get();
         $faqs = Faq::latest()->limit(3)->get();
+        $trusted_partners = TrustedPartner::latest()->limit(4)->get();
+        $business_partners = BusinessPartner::latest()->limit(3)->get();
 
         $homePage = PageSetting::where('page_name', 'home')->first();
         $homeSettings = $homePage ? $homePage->settings : [];
@@ -42,6 +46,8 @@ class HomeController extends Controller
             'working_processes' => $working_processes,
             'faqs' => $faqs,
             'contactSettings' => $contactSettings,
+            'trusted_partners' => $trusted_partners,
+            'business_partners' => $business_partners,
         ]);
     }
 }

--- a/app/Models/BusinessPartner.php
+++ b/app/Models/BusinessPartner.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models;
+
+use App\Http\Controllers\Traits\FileUploadTrait;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class BusinessPartner extends Model
+{
+    use HasFactory, FileUploadTrait;
+
+    protected $fillable = ['name', 'logo'];
+}

--- a/app/Models/TrustedPartner.php
+++ b/app/Models/TrustedPartner.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Models;
+
+use App\Http\Controllers\Traits\FileUploadTrait;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class TrustedPartner extends Model
+{
+    use HasFactory, FileUploadTrait;
+
+    protected $fillable = ['name', 'logo'];
+}

--- a/database/migrations/2025_10_27_235116_create_trusted_partners_table.php
+++ b/database/migrations/2025_10_27_235116_create_trusted_partners_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('trusted_partners', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('logo');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('trusted_partners');
+    }
+};

--- a/database/migrations/2025_10_27_235250_create_business_partners_table.php
+++ b/database/migrations/2025_10_27_235250_create_business_partners_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('business_partners', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('logo');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('business_partners');
+    }
+};

--- a/database/seeders/BusinessPartnerSeeder.php
+++ b/database/seeders/BusinessPartnerSeeder.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\BusinessPartner;
+
+class BusinessPartnerSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        BusinessPartner::updateOrCreate(
+            ['name' => 'Partner 1'],
+            ['logo' => 'partner-1.png']
+        );
+        BusinessPartner::updateOrCreate(
+            ['name' => 'Partner 2'],
+            ['logo' => 'partner-2.png']
+        );
+        BusinessPartner::updateOrCreate(
+            ['name' => 'Partner 3'],
+            ['logo' => 'partner-3.png']
+        );
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -43,6 +43,8 @@ class DatabaseSeeder extends Seeder
             SocialMediaLinkSeeder::class,
             PageSettingSeeder::class,
             MenuSeeder::class,
+            TrustedPartnerSeeder::class,
+            BusinessPartnerSeeder::class,
         ]);
     }
 }

--- a/database/seeders/TrustedPartnerSeeder.php
+++ b/database/seeders/TrustedPartnerSeeder.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\TrustedPartner;
+
+class TrustedPartnerSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        TrustedPartner::updateOrCreate(
+            ['name' => 'Fiverr'],
+            ['logo' => 'fiverr.svg']
+        );
+        TrustedPartner::updateOrCreate(
+            ['name' => 'Envato'],
+            ['logo' => 'envato.svg']
+        );
+        TrustedPartner::updateOrCreate(
+            ['name' => 'Upwork'],
+            ['logo' => 'upwork-2.svg']
+        );
+        TrustedPartner::updateOrCreate(
+            ['name' => 'PeoplePerHour'],
+            ['logo' => 'peopleperhour.svg']
+        );
+    }
+}

--- a/resources/views/frontend/home.blade.php
+++ b/resources/views/frontend/home.blade.php
@@ -19,11 +19,11 @@
         </div>
 
         <div class="mt-8 md:mt-14">
-            <p class="text-center text-secondary-800 body-text-regular-medium">Our business partner</p>
+            <p class="text-center text-secondary-800 body-text-regular-medium">{{ $homeSettings['business_partner_title'] ?? '' }}</p>
             <div class="flex justify-center items-center gap-4 mt-4">
-                <img src="{{ asset('frontend/images/partner-1.png') }}" alt="">
-                <img src="{{ asset('frontend/images/partner-2.png') }}" alt="">
-                <img src="{{ asset('frontend/images/partner-3.png') }}" alt="">
+                @foreach ($business_partners as $partner)
+                    <img src="{{ asset('frontend/images/' . $partner->logo) }}" alt="{{ $partner->name }}">
+                @endforeach
             </div>
         </div>
 
@@ -484,16 +484,13 @@
 
 {{-- Companies who trust us start --}}
 <div class="mt-10 md:mt-15 mb-10 md:mb-20">
-    <h2 class="heading-text-regular-medium text-center text-secondary-900 text-2xl md:text-3xl">Companies who Trust Us
+    <h2 class="heading-text-regular-medium text-center text-secondary-900 text-2xl md:text-3xl">{{ $homeSettings['trusted_partners_title'] ?? '' }}
     </h2>
-    <p class="sub-title-medium-regular text-center text-secondary-600 w-full md:w-8/12 lg:w-7/12 mx-auto mt-4">We are
-        proud to serve businesses and organizations across multiple countries and industries. We helped clients
-        worldwide achieve success in the digital landscape.</p>
+    <p class="sub-title-medium-regular text-center text-secondary-600 w-full md:w-8/12 lg:w-7/12 mx-auto mt-4">{{ $homeSettings['trusted_partners_description'] ?? '' }}</p>
     <div class="flex flex-wrap justify-center items-center gap-10 sm:gap-20 mt-8">
-        <img src="{{ asset('upload/fiverr.svg') }}" alt="Fiverr">
-        <img src="{{ asset('upload/envato.svg') }}" alt="Envato">
-        <img src="{{ asset('upload/upwork-2.svg') }}" alt="Upwork">
-        <img src="{{ asset('upload/peopleperhour.svg') }}" alt="PeoplePerHour">
+        @foreach ($trusted_partners as $partner)
+            <img src="{{ asset('upload/' . $partner->logo) }}" alt="{{ $partner->name }}">
+        @endforeach
     </div>
 </div>
 {{-- Companies who trust us end --}}


### PR DESCRIPTION
This commit makes the "business partners" and "trusted partners" sections of the homepage dynamic.

It introduces two new models, `BusinessPartner` and `TrustedPartner`, along with their corresponding migrations and seeders. The `HomeController` has been updated to fetch this data, and the `home.blade.php` view has been modified to render it dynamically.

This addresses a portion of the user's request to make the entire homepage dynamic. The image paths have been corrected to ensure that the logos are displayed correctly.