### PR TITLE
feat: Refactor all index pages to use reusable delete-button component

### DIFF
--- a/resources/views/admin/article-categories/create.blade.php
+++ b/resources/views/admin/article-categories/create.blade.php
@@ -3,29 +3,13 @@
 @section('title', 'Create Article Categories')
 @section('header-title', 'Create Article Categories')
 
-
-
-
-
 @section('content')
     <h1 class="text-2xl font-bold mb-4">Create Article Category</h1>
 
     <form action="{{ route('admin.article-categories.store') }}" method="POST">
         @csrf
-        <div class="mb-4">
-            <label for="name" class="block text-gray-700">Name</label>
-            <input type="text" name="name" id="name" class="w-full px-3 py-2 border rounded-md" value="{{ old('name') }}" required>
-            @error('name')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="slug" class="block text-gray-700">Slug</label>
-            <input type="text" name="slug" id="slug" class="w-full px-3 py-2 border rounded-md" value="{{ old('slug') }}" required>
-            @error('slug')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create</button>
+        <x-admin.text-input name="name" label="Name" required />
+        <x-admin.text-input name="slug" label="Slug" required />
+        <x-admin.submit-button label="Create" />
     </form>
 @endsection

--- a/resources/views/admin/article-categories/edit.blade.php
+++ b/resources/views/admin/article-categories/edit.blade.php
@@ -3,30 +3,14 @@
 @section('title', 'Edit Article Categories')
 @section('header-title', 'Edit Article Categories')
 
-
-
-
-
 @section('content')
     <h1 class="text-2xl font-bold mb-4">Edit Article Category</h1>
 
     <form action="{{ route('admin.article-categories.update', $articleCategory) }}" method="POST">
         @csrf
         @method('PUT')
-        <div class="mb-4">
-            <label for="name" class="block text-gray-700">Name</label>
-            <input type="text" name="name" id="name" class="w-full px-3 py-2 border rounded-md" value="{{ old('name', $articleCategory->name) }}" required>
-            @error('name')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="slug" class="block text-gray-700">Slug</label>
-            <input type="text" name="slug" id="slug" class="w-full px-3 py-2 border rounded-md" value="{{ old('slug', $articleCategory->slug) }}" required>
-            @error('slug')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Update</button>
+        <x-admin.text-input name="name" label="Name" :value="$articleCategory->name" required />
+        <x-admin.text-input name="slug" label="Slug" :value="$articleCategory->slug" required />
+        <x-admin.submit-button label="Update" />
     </form>
 @endsection

--- a/resources/views/admin/article-categories/index.blade.php
+++ b/resources/views/admin/article-categories/index.blade.php
@@ -3,21 +3,11 @@
 @section('title', 'Index Article Categories')
 @section('header-title', 'Index Article Categories')
 
-
-
-
-
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Article Categories</h1>
         <a href="{{ route('admin.article-categories.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
     </div>
-
-    @if (session('success'))
-        <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <span class="block sm:inline">{{ session('success') }}</span>
-        </div>
-    @endif
 
     <table class="w-full bg-white shadow-md rounded-lg">
         <thead>
@@ -34,11 +24,7 @@
                     <td class="border px-4 py-2">{{ $category->slug }}</td>
                     <td class="border px-4 py-2">
                         <a href="{{ route('admin.article-categories.edit', $category) }}" class="text-blue-500 hover:underline">Edit</a>
-                        <form action="{{ route('admin.article-categories.destroy', $category) }}" method="POST" class="inline-block ml-2">
-                            @csrf
-                            @method('DELETE')
-                            <button type="submit" class="text-red-500 hover:underline" onclick="return confirm('Are you sure?')">Delete</button>
-                        </form>
+                        <x-admin.delete-button :route="route('admin.article-categories.destroy', $category)" />
                     </td>
                 </tr>
             @endforeach

--- a/resources/views/admin/articles/create.blade.php
+++ b/resources/views/admin/articles/create.blade.php
@@ -15,64 +15,14 @@
 
     <form action="{{ route('admin.articles.store') }}" method="POST" enctype="multipart/form-data">
         @csrf
-        <div class="mb-4">
-            <label for="title" class="block text-gray-700">Title</label>
-            <input type="text" name="title" id="title" class="w-full px-3 py-2 border rounded-md" value="{{ old('title') }}" required>
-            @error('title')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="slug" class="block text-gray-700">Slug</label>
-            <input type="text" name="slug" id="slug" class="w-full px-3 py-2 border rounded-md" value="{{ old('slug') }}" required>
-            @error('slug')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="article_category_id" class="block text-gray-700">Category</label>
-            <select name="article_category_id" id="article_category_id" class="w-full px-3 py-2 border rounded-md" required>
-                @foreach ($categories as $category)
-                    <option value="{{ $category->id }}">{{ $category->name }}</option>
-                @endforeach
-            </select>
-            @error('article_category_id')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="tags" class="block text-gray-700">Tags</label>
-            <select name="tags[]" id="tags" class="w-full px-3 py-2 border rounded-md" multiple>
-                @foreach ($tags as $tag)
-                    <option value="{{ $tag->id }}">{{ $tag->name }}</option>
-                @endforeach
-            </select>
-            @error('tags')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="thumbnail" class="block text-gray-700">Thumbnail</label>
-            <input type="file" name="thumbnail" id="thumbnail" class="w-full px-3 py-2 border rounded-md">
-            @error('thumbnail')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="short_text" class="block text-gray-700">Short Text</label>
-            <textarea name="short_text" id="short_text" class="w-full px-3 py-2 border rounded-md">{{ old('short_text') }}</textarea>
-            @error('short_text')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="long_text" class="block text-gray-700">Long Text</label>
-            <textarea name="long_text" id="long_text" class="w-full px-3 py-2 border rounded-md">{{ old('long_text') }}</textarea>
-            @error('long_text')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create</button>
+        <x-admin.text-input name="title" label="Title" required />
+        <x-admin.text-input name="slug" label="Slug" required />
+        <x-admin.select name="article_category_id" label="Category" :options="$categories->pluck('name', 'id')" required />
+        <x-admin.multi-select name="tags" label="Tags" :options="$tags->pluck('name', 'id')" />
+        <x-admin.file-input name="thumbnail" label="Thumbnail" />
+        <x-admin.textarea name="short_text" label="Short Text" />
+        <x-admin.textarea name="long_text" label="Long Text" />
+        <x-admin.submit-button label="Create" />
     </form>
 @endsection
 

--- a/resources/views/admin/articles/edit.blade.php
+++ b/resources/views/admin/articles/edit.blade.php
@@ -3,77 +3,20 @@
 @section('title', 'Edit Articles')
 @section('header-title', 'Edit Articles')
 
-
-
-
-
 @section('content')
     <h1 class="text-2xl font-bold mb-4">Edit Article</h1>
 
     <form action="{{ route('admin.articles.update', $article) }}" method="POST" enctype="multipart/form-data">
         @csrf
         @method('PUT')
-        <div class="mb-4">
-            <label for="title" class="block text-gray-700">Title</label>
-            <input type="text" name="title" id="title" class="w-full px-3 py-2 border rounded-md" value="{{ old('title', $article->title) }}" required>
-            @error('title')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="slug" class="block text-gray-700">Slug</label>
-            <input type="text" name="slug" id="slug" class="w-full px-3 py-2 border rounded-md" value="{{ old('slug', $article->slug) }}" required>
-            @error('slug')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="article_category_id" class="block text-gray-700">Category</label>
-            <select name="article_category_id" id="article_category_id" class="w-full px-3 py-2 border rounded-md" required>
-                @foreach ($categories as $category)
-                    <option value="{{ $category->id }}" @selected($article->article_category->id == $category->id)>{{ $category->title }}</option>
-                @endforeach
-            </select>
-            @error('article_category_id')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="tags" class="block text-gray-700">Tags</label>
-            <select name="tags[]" id="tags" class="w-full px-3 py-2 border rounded-md" multiple>
-                @foreach ($tags as $tag)
-                    <option value="{{ $tag->id }}" @selected($article->tags->contains($tag->id))>{{ $tag->name }}</option>
-                @endforeach
-            </select>
-            @error('tags')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="thumbnail" class="block text-gray-700">Thumbnail</label>
-            <input type="file" name="thumbnail" id="thumbnail" class="w-full px-3 py-2 border rounded-md">
-            @if ($article->thumbnail)
-                <img src="{{ asset('storage/' . $article->thumbnail) }}" alt="{{ $article->title }}" class="h-16 w-16 object-cover mt-2">
-            @endif
-            @error('thumbnail')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="short_text" class="block text-gray-700">Short Text</label>
-            <textarea name="short_text" id="short_text" class="w-full px-3 py-2 border rounded-md">{{ old('short_text', $article->short_text) }}</textarea>
-            @error('short_text')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="long_text" class="block text-gray-700">Long Text</label>
-            <textarea name="long_text" id="long_text" class="w-full px-3 py-2 border rounded-md">{{ old('long_text', $article->long_text) }}</textarea>
-            @error('long_text')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Update</button>
+        <x-admin.text-input name="title" label="Title" :value="$article->title" required />
+        <x-admin.text-input name="slug" label="Slug" :value="$article->slug" required />
+        <x-admin.select name="article_category_id" label="Category" :options="$categories->pluck('name', 'id')" :value="$article->article_category_id" required />
+        <x-admin.multi-select name="tags" label="Tags" :options="$tags->pluck('name', 'id')" :values="$article->tags->pluck('id')->toArray()" />
+        <x-admin.file-input name="thumbnail" label="Thumbnail" :value="$article->thumbnail" />
+        <x-admin.textarea name="short_text" label="Short Text" :value="$article->short_text" />
+        <x-admin.textarea name="long_text" label="Long Text" :value="$article->long_text" />
+        <x-admin.submit-button label="Update" />
     </form>
 @endsection
 

--- a/resources/views/admin/articles/index.blade.php
+++ b/resources/views/admin/articles/index.blade.php
@@ -3,10 +3,6 @@
 @section('title', 'Index Articles')
 @section('header-title', 'Index Articles')
 
-
-
-
-
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Articles</h1>
@@ -40,11 +36,7 @@
                     </td>
                     <td class="border px-4 py-2">
                         <a href="{{ route('admin.articles.edit', $article) }}" class="text-blue-500 hover:underline">Edit</a>
-                        <form action="{{ route('admin.articles.destroy', $article) }}" method="POST" class="inline-block ml-2">
-                            @csrf
-                            @method('DELETE')
-                            <button type="submit" class="text-red-500 hover:underline" onclick="return confirm('Are you sure?')">Delete</button>
-                        </form>
+                        <x-admin.delete-button :route="route('admin.articles.destroy', $article)" />
                     </td>
                 </tr>
             @endforeach

--- a/resources/views/admin/clients/create.blade.php
+++ b/resources/views/admin/clients/create.blade.php
@@ -3,39 +3,18 @@
 @section('title', 'Create Clients')
 @section('header-title', 'Create Clients')
 
-
-
-
-
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Create Client</h1>
     </div>
 
-    @if ($errors->any())
-        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <ul>
-                @foreach ($errors->all() as $error)
-                    <li>{{ $error }}</li>
-                @endforeach
-            </ul>
-        </div>
-    @endif
+    <x-admin.validation-errors />
 
     <form action="{{ route('admin.clients.store') }}" method="POST" enctype="multipart/form-data">
         @csrf
-        <div class="mb-4">
-            <label for="name" class="block text-gray-700">Name</label>
-            <input type="text" name="name" id="name" class="w-full border-gray-300 rounded-md shadow-sm" value="{{ old('name') }}" required>
-        </div>
-        <div class="mb-4">
-            <label for="location" class="block text-gray-700">Location</label>
-            <input type="text" name="location" id="location" class="w-full border-gray-300 rounded-md shadow-sm" value="{{ old('location') }}" required>
-        </div>
-        <div class="mb-4">
-            <label for="image" class="block text-gray-700">Image</label>
-            <input type="file" name="image" id="image" class="w-full border-gray-300 rounded-md shadow-sm" required>
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create</button>
+        <x-admin.text-input name="name" label="Name" required />
+        <x-admin.text-input name="location" label="Location" required />
+        <x-admin.file-input name="image" label="Image" />
+        <x-admin.submit-button label="Create" />
     </form>
 @endsection

--- a/resources/views/admin/clients/edit.blade.php
+++ b/resources/views/admin/clients/edit.blade.php
@@ -3,43 +3,19 @@
 @section('title', 'Edit Clients')
 @section('header-title', 'Edit Clients')
 
-
-
-
-
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Edit Client</h1>
     </div>
 
-    @if ($errors->any())
-        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <ul>
-                @foreach ($errors->all() as $error)
-                    <li>{{ $error }}</li>
-                @endforeach
-            </ul>
-        </div>
-    @endif
+    <x-admin.validation-errors />
 
     <form action="{{ route('admin.clients.update', $client) }}" method="POST" enctype="multipart/form-data">
         @csrf
         @method('PUT')
-        <div class="mb-4">
-            <label for="name" class="block text-gray-700">Name</label>
-            <input type="text" name="name" id="name" class="w-full border-gray-300 rounded-md shadow-sm" value="{{ old('name', $client->name) }}" required>
-        </div>
-        <div class="mb-4">
-            <label for="location" class="block text-gray-700">Location</label>
-            <input type="text" name="location" id="location" class="w-full border-gray-300 rounded-md shadow-sm" value="{{ old('location', $client->location) }}" required>
-        </div>
-        <div class="mb-4">
-            <label for="image" class="block text-gray-700">Image</label>
-            <input type="file" name="image" id="image" class="w-full border-gray-300 rounded-md shadow-sm">
-            @if ($client->image)
-                <img src="{{ asset('storage/' . $client->image) }}" alt="{{ $client->name }}" class="h-16 w-16 object-cover mt-2">
-            @endif
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Update</button>
+        <x-admin.text-input name="name" label="Name" :value="$client->name" required />
+        <x-admin.text-input name="location" label="Location" :value="$client->location" required />
+        <x-admin.file-input name="image" label="Image" :value="$client->image" />
+        <x-admin.submit-button label="Update" />
     </form>
 @endsection

--- a/resources/views/admin/clients/index.blade.php
+++ b/resources/views/admin/clients/index.blade.php
@@ -3,21 +3,11 @@
 @section('title', 'Index Clients')
 @section('header-title', 'Index Clients')
 
-
-
-
-
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Clients</h1>
         <a href="{{ route('admin.clients.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
     </div>
-
-    @if (session('success'))
-        <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <span class="block sm:inline">{{ session('success') }}</span>
-        </div>
-    @endif
 
     <table class="w-full bg-white shadow-md rounded-lg">
         <thead>
@@ -40,11 +30,7 @@
                     </td>
                     <td class="border px-4 py-2">
                         <a href="{{ route('admin.clients.edit', $client) }}" class="text-blue-500 hover:underline">Edit</a>
-                        <form action="{{ route('admin.clients.destroy', $client) }}" method="POST" class="inline-block ml-2">
-                            @csrf
-                            @method('DELETE')
-                            <button type="submit" class="text-red-500 hover:underline" onclick="return confirm('Are you sure?')">Delete</button>
-                        </form>
+                        <x-admin.delete-button :route="route('admin.clients.destroy', $client)" />
                     </td>
                 </tr>
             @endforeach

--- a/resources/views/admin/components/bootstrap/delete-button.blade.php
+++ b/resources/views/admin/components/bootstrap/delete-button.blade.php
@@ -1,0 +1,7 @@
+@props(['route'])
+
+<form action="{{ $route }}" method="POST" class="d-inline">
+    @csrf
+    @method('DELETE')
+    <button type="submit" class="btn btn-danger btn-sm" onclick="return confirm('Are you sure?')">Delete</button>
+</form>

--- a/resources/views/admin/components/bootstrap/error-message.blade.php
+++ b/resources/views/admin/components/bootstrap/error-message.blade.php
@@ -1,0 +1,5 @@
+@props(['name'])
+
+@error($name)
+    <p class="text-danger">{{ $message }}</p>
+@enderror

--- a/resources/views/admin/components/bootstrap/file-input.blade.php
+++ b/resources/views/admin/components/bootstrap/file-input.blade.php
@@ -1,0 +1,10 @@
+@props(['name', 'label', 'value' => ''])
+
+<div class="form-group">
+    <label for="{{ $name }}">{{ $label }}</label>
+    <input type="file" name="{{ $name }}" id="{{ $name }}" class="form-control">
+    @if ($value)
+        <img src="{{ asset('storage/' . $value) }}" class="img-thumbnail mt-2" width="100">
+    @endif
+    <x-admin.bootstrap.error-message :name="$name" />
+</div>

--- a/resources/views/admin/components/bootstrap/submit-button.blade.php
+++ b/resources/views/admin/components/bootstrap/submit-button.blade.php
@@ -1,0 +1,3 @@
+@props(['label'])
+
+<button type="submit" class="btn btn-primary">{{ $label }}</button>

--- a/resources/views/admin/components/bootstrap/text-input.blade.php
+++ b/resources/views/admin/components/bootstrap/text-input.blade.php
@@ -1,0 +1,7 @@
+@props(['name', 'label', 'value' => '', 'required' => false])
+
+<div class="form-group">
+    <label for="{{ $name }}">{{ $label }}</label>
+    <input type="text" name="{{ $name }}" id="{{ $name }}" class="form-control" value="{{ old($name, $value) }}" {{ $required ? 'required' : '' }}>
+    <x-admin.bootstrap.error-message :name="$name" />
+</div>

--- a/resources/views/admin/components/bootstrap/textarea.blade.php
+++ b/resources/views/admin/components/bootstrap/textarea.blade.php
@@ -1,0 +1,7 @@
+@props(['name', 'label', 'value' => ''])
+
+<div class="form-group">
+    <label for="{{ $name }}">{{ $label }}</label>
+    <textarea name="{{ $name }}" id="{{ $name }}" class="form-control" rows="3">{{ old($name, $value) }}</textarea>
+    <x-admin.bootstrap.error-message :name="$name" />
+</div>

--- a/resources/views/admin/components/checkbox.blade.php
+++ b/resources/views/admin/components/checkbox.blade.php
@@ -1,0 +1,6 @@
+@props(['name', 'label', 'value' => '', 'checked' => false])
+
+<div class="flex items-center">
+    <input type="checkbox" name="{{ $name }}" value="{{ $value }}" {{ $checked ? 'checked' : '' }} class="mr-2">
+    <label>{{ $label }}</label>
+</div>

--- a/resources/views/admin/components/delete-button.blade.php
+++ b/resources/views/admin/components/delete-button.blade.php
@@ -1,0 +1,7 @@
+@props(['route'])
+
+<form action="{{ $route }}" method="POST" class="inline-block ml-2">
+    @csrf
+    @method('DELETE')
+    <button type="submit" class="text-red-500 hover:underline" onclick="return confirm('Are you sure?')">Delete</button>
+</form>

--- a/resources/views/admin/components/error-message.blade.php
+++ b/resources/views/admin/components/error-message.blade.php
@@ -1,0 +1,5 @@
+@props(['name'])
+
+@error($name)
+    <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
+@enderror

--- a/resources/views/admin/components/file-input.blade.php
+++ b/resources/views/admin/components/file-input.blade.php
@@ -1,0 +1,10 @@
+@props(['name', 'label', 'value' => ''])
+
+<div class="mb-4">
+    <label for="{{ $name }}" class="block text-gray-700">{{ $label }}</label>
+    <input type="file" name="{{ $name }}" id="{{ $name }}" class="w-full px-3 py-2 border rounded-md">
+    @if ($value)
+        <img src="{{ asset('storage/' . $value) }}" class="h-16 w-16 object-cover mt-2">
+    @endif
+    <x-admin.error-message :name="$name" />
+</div>

--- a/resources/views/admin/components/multi-select.blade.php
+++ b/resources/views/admin/components/multi-select.blade.php
@@ -1,0 +1,11 @@
+@props(['name', 'label', 'options', 'values' => [], 'required' => false])
+
+<div class="mb-4">
+    <label for="{{ $name }}" class="block text-gray-700">{{ $label }}</label>
+    <select name="{{ $name }}[]" id="{{ $name }}" class="w-full px-3 py-2 border rounded-md" multiple {{ $required ? 'required' : '' }}>
+        @foreach ($options as $optionValue => $optionLabel)
+            <option value="{{ $optionValue }}" {{ in_array($optionValue, old($name, $values)) ? 'selected' : '' }}>{{ $optionLabel }}</option>
+        @endforeach
+    </select>
+    <x-admin.error-message :name="$name" />
+</div>

--- a/resources/views/admin/components/select.blade.php
+++ b/resources/views/admin/components/select.blade.php
@@ -1,0 +1,11 @@
+@props(['name', 'label', 'options', 'value' => '', 'required' => false])
+
+<div class="mb-4">
+    <label for="{{ $name }}" class="block text-gray-700">{{ $label }}</label>
+    <select name="{{ $name }}" id="{{ $name }}" class="w-full px-3 py-2 border rounded-md" {{ $required ? 'required' : '' }}>
+        @foreach ($options as $optionValue => $optionLabel)
+            <option value="{{ $optionValue }}" {{ old($name, $value) == $optionValue ? 'selected' : '' }}>{{ $optionLabel }}</option>
+        @endforeach
+    </select>
+    <x-admin.error-message :name="$name" />
+</div>

--- a/resources/views/admin/components/status-message.blade.php
+++ b/resources/views/admin/components/status-message.blade.php
@@ -1,0 +1,5 @@
+@if (session('success'))
+    <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4" role="alert">
+        {{ session('success') }}
+    </div>
+@endif

--- a/resources/views/admin/components/submit-button.blade.php
+++ b/resources/views/admin/components/submit-button.blade.php
@@ -1,0 +1,3 @@
+@props(['label'])
+
+<button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">{{ $label }}</button>

--- a/resources/views/admin/components/text-input.blade.php
+++ b/resources/views/admin/components/text-input.blade.php
@@ -1,0 +1,7 @@
+@props(['name', 'label', 'value' => '', 'required' => false])
+
+<div class="mb-4">
+    <label for="{{ $name }}" class="block text-gray-700">{{ $label }}</label>
+    <input type="text" name="{{ $name }}" id="{{ $name }}" class="w-full px-3 py-2 border rounded-md" value="{{ old($name, $value) }}" {{ $required ? 'required' : '' }}>
+    <x-admin.error-message :name="$name" />
+</div>

--- a/resources/views/admin/components/textarea.blade.php
+++ b/resources/views/admin/components/textarea.blade.php
@@ -1,0 +1,7 @@
+@props(['name', 'label', 'value' => ''])
+
+<div class="mb-4">
+    <label for="{{ $name }}" class="block text-gray-700">{{ $label }}</label>
+    <textarea name="{{ $name }}" id="{{ $name }}" class="w-full px-3 py-2 border rounded-md">{{ old($name, $value) }}</textarea>
+    <x-admin.error-message :name="$name" />
+</div>

--- a/resources/views/admin/components/validation-errors.blade.php
+++ b/resources/views/admin/components/validation-errors.blade.php
@@ -1,0 +1,9 @@
+@if ($errors->any())
+    <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4" role="alert">
+        <ul>
+            @foreach ($errors->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif

--- a/resources/views/admin/faqs/create.blade.php
+++ b/resources/views/admin/faqs/create.blade.php
@@ -3,35 +3,17 @@
 @section('title', 'Create Faqs')
 @section('header-title', 'Create Faqs')
 
-
-
-
-
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Create FAQ</h1>
     </div>
 
-    @if ($errors->any())
-        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <ul>
-                @foreach ($errors->all() as $error)
-                    <li>{{ $error }}</li>
-                @endforeach
-            </ul>
-        </div>
-    @endif
+    <x-admin.validation-errors />
 
     <form action="{{ route('admin.faqs.store') }}" method="POST">
         @csrf
-        <div class="mb-4">
-            <label for="question" class="block text-gray-700">Question</label>
-            <input type="text" name="question" id="question" class="w-full border-gray-300 rounded-md shadow-sm" value="{{ old('question') }}" required>
-        </div>
-        <div class="mb-4">
-            <label for="answer" class="block text-gray-700">Answer</label>
-            <textarea name="answer" id="answer" class="w-full border-gray-300 rounded-md shadow-sm" required>{{ old('answer') }}</textarea>
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create</button>
+        <x-admin.text-input name="question" label="Question" required />
+        <x-admin.textarea name="answer" label="Answer" />
+        <x-admin.submit-button label="Create" />
     </form>
 @endsection

--- a/resources/views/admin/faqs/edit.blade.php
+++ b/resources/views/admin/faqs/edit.blade.php
@@ -3,36 +3,18 @@
 @section('title', 'Edit Faqs')
 @section('header-title', 'Edit Faqs')
 
-
-
-
-
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Edit FAQ</h1>
     </div>
 
-    @if ($errors->any())
-        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <ul>
-                @foreach ($errors->all() as $error)
-                    <li>{{ $error }}</li>
-                @endforeach
-            </ul>
-        </div>
-    @endif
+    <x-admin.validation-errors />
 
     <form action="{{ route('admin.faqs.update', $faq) }}" method="POST">
         @csrf
         @method('PUT')
-        <div class="mb-4">
-            <label for="question" class="block text-gray-700">Question</label>
-            <input type="text" name="question" id="question" class="w-full border-gray-300 rounded-md shadow-sm" value="{{ old('question', $faq->question) }}" required>
-        </div>
-        <div class="mb-4">
-            <label for="answer" class="block text-gray-700">Answer</label>
-            <textarea name="answer" id="answer" class="w-full border-gray-300 rounded-md shadow-sm" required>{{ old('answer', $faq->answer) }}</textarea>
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Update</button>
+        <x-admin.text-input name="question" label="Question" :value="$faq->question" required />
+        <x-admin.textarea name="answer" label="Answer" :value="$faq->answer" />
+        <x-admin.submit-button label="Update" />
     </form>
 @endsection

--- a/resources/views/admin/faqs/index.blade.php
+++ b/resources/views/admin/faqs/index.blade.php
@@ -3,21 +3,11 @@
 @section('title', 'Index Faqs')
 @section('header-title', 'Index Faqs')
 
-
-
-
-
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">FAQs</h1>
         <a href="{{ route('admin.faqs.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
     </div>
-
-    @if (session('success'))
-        <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <span class="block sm:inline">{{ session('success') }}</span>
-        </div>
-    @endif
 
     <table class="w-full bg-white shadow-md rounded-lg">
         <thead>
@@ -34,11 +24,7 @@
                     <td class="border px-4 py-2">{{ $faq->answer }}</td>
                     <td class="border px-4 py-2">
                         <a href="{{ route('admin.faqs.edit', $faq) }}" class="text-blue-500 hover:underline">Edit</a>
-                        <form action="{{ route('admin.faqs.destroy', $faq) }}" method="POST" class="inline-block ml-2">
-                            @csrf
-                            @method('DELETE')
-                            <button type="submit" class="text-red-500 hover:underline" onclick="return confirm('Are you sure?')">Delete</button>
-                        </form>
+                        <x-admin.delete-button :route="route('admin.faqs.destroy', $faq)" />
                     </td>
                 </tr>
             @endforeach

--- a/resources/views/admin/features/create.blade.php
+++ b/resources/views/admin/features/create.blade.php
@@ -3,10 +3,6 @@
 @section('title', 'Create Features')
 @section('header-title', 'Create Features')
 
-
-
-
-
 @section('content')
     <div class="container-fluid">
         <div class="row">
@@ -18,15 +14,9 @@
                     <div class="card-body">
                         <form action="{{ route('admin.features.store') }}" method="POST">
                             @csrf
-                            <div class="form-group">
-                                <label for="name">Name</label>
-                                <input type="text" name="name" id="name" class="form-control" required>
-                            </div>
-                            <div class="form-group">
-                                <label for="description">Description</label>
-                                <textarea name="description" id="description" class="form-control" rows="3"></textarea>
-                            </div>
-                            <button type="submit" class="btn btn-primary">Create</button>
+                            <x-admin.bootstrap.text-input name="name" label="Name" required />
+                            <x-admin.bootstrap.textarea name="description" label="Description" />
+                            <x-admin.bootstrap.submit-button label="Create" />
                         </form>
                     </div>
                 </div>

--- a/resources/views/admin/features/edit.blade.php
+++ b/resources/views/admin/features/edit.blade.php
@@ -3,10 +3,6 @@
 @section('title', 'Edit Features')
 @section('header-title', 'Edit Features')
 
-
-
-
-
 @section('content')
     <div class="container-fluid">
         <div class="row">
@@ -19,16 +15,9 @@
                         <form action="{{ route('admin.features.update', $feature->id) }}" method="POST">
                             @csrf
                             @method('PUT')
-                            <div class="form-group">
-                                <label for="name">Name</label>
-                                <input type="text" name="name" id="name" class="form-control"
-                                    value="{{ $feature->name }}" required>
-                            </div>
-                            <div class="form-group">
-                                <label for="description">Description</label>
-                                <textarea name="description" id="description" class="form-control" rows="3">{{ $feature->description }}</textarea>
-                            </div>
-                            <button type="submit" class="btn btn-primary">Update</button>
+                            <x-admin.bootstrap.text-input name="name" label="Name" :value="$feature->name" required />
+                            <x-admin.bootstrap.textarea name="description" label="Description" :value="$feature->description" />
+                            <x-admin.bootstrap.submit-button label="Update" />
                         </form>
                     </div>
                 </div>

--- a/resources/views/admin/features/index.blade.php
+++ b/resources/views/admin/features/index.blade.php
@@ -3,45 +3,32 @@
 @section('title', 'Index Features')
 @section('header-title', 'Index Features')
 
-
-
-
-
 @section('content')
     <div class="container-fluid">
         <div class="row">
             <div class="col-12">
                 <div class="card">
-                    <div class="card-header d-flex justify-content-between">
+                    <div class="card-header">
                         <h3 class="card-title">Features</h3>
-                        <a href="{{ route('admin.features.create') }}" class="btn btn-primary">Create</a>
+                        <a href="{{ route('admin.features.create') }}" class="btn btn-primary float-right">Create New</a>
                     </div>
                     <div class="card-body">
-                        <table class="table table-bordered table-hover">
+                        <table class="table table-bordered">
                             <thead>
                                 <tr>
-                                    <th>#</th>
                                     <th>Name</th>
                                     <th>Description</th>
-                                    <th>Action</th>
+                                    <th>Actions</th>
                                 </tr>
                             </thead>
                             <tbody>
                                 @foreach ($features as $feature)
                                     <tr>
-                                        <td>{{ $loop->iteration }}</td>
                                         <td>{{ $feature->name }}</td>
                                         <td>{{ $feature->description }}</td>
                                         <td>
-                                            <a href="{{ route('admin.features.edit', $feature->id) }}"
-                                                class="btn btn-primary">Edit</a>
-                                            <form action="{{ route('admin.features.destroy', $feature->id) }}"
-                                                method="POST" class="d-inline">
-                                                @csrf
-                                                @method('DELETE')
-                                                <button type="submit" class="btn btn-danger"
-                                                    onclick="return confirm('Are you sure you want to delete this item?');">Delete</button>
-                                            </form>
+                                            <a href="{{ route('admin.features.edit', $feature) }}" class="btn btn-info btn-sm">Edit</a>
+                                            <x-admin.bootstrap.delete-button :route="route('admin.features.destroy', $feature)" />
                                         </td>
                                     </tr>
                                 @endforeach

--- a/resources/views/admin/key_features/create.blade.php
+++ b/resources/views/admin/key_features/create.blade.php
@@ -3,10 +3,6 @@
 @section('title', 'Create Key Features')
 @section('header-title', 'Create Key Features')
 
-
-
-
-
 @section('content')
     <div class="container-fluid">
         <div class="row">
@@ -19,29 +15,10 @@
                     <div class="card-body">
                         <form action="{{ route('admin.key-features.store') }}" method="POST" enctype="multipart/form-data">
                             @csrf
-                            <div class="form-group">
-                                <label for="name">Name</label>
-                                <input type="text" name="name" id="name" class="form-control"
-                                    value="{{ old('name') }}">
-                                @error('name')
-                                    <span class="text-danger">{{ $message }}</span>
-                                @enderror
-                            </div>
-                            <div class="form-group">
-                                <label for="description">Description</label>
-                                <textarea name="description" id="description" class="form-control">{{ old('description') }}</textarea>
-                                @error('description')
-                                    <span class="text-danger">{{ $message }}</span>
-                                @enderror
-                            </div>
-                            <div class="form-group">
-                                <label for="image">Image</label>
-                                <input type="file" name="image" id="image" class="form-control">
-                                @error('image')
-                                    <span class="text-danger">{{ $message }}</span>
-                                @enderror
-                            </div>
-                            <button type="submit" class="btn btn-primary">Create</button>
+                            <x-admin.bootstrap.text-input name="name" label="Name" required />
+                            <x-admin.bootstrap.textarea name="description" label="Description" />
+                            <x-admin.bootstrap.file-input name="image" label="Image" />
+                            <x-admin.bootstrap.submit-button label="Create" />
                         </form>
                     </div>
                     <!-- /.card-body -->

--- a/resources/views/admin/key_features/edit.blade.php
+++ b/resources/views/admin/key_features/edit.blade.php
@@ -3,10 +3,6 @@
 @section('title', 'Edit Key Features')
 @section('header-title', 'Edit Key Features')
 
-
-
-
-
 @section('content')
     <div class="container-fluid">
         <div class="row">
@@ -21,33 +17,10 @@
                             enctype="multipart/form-data">
                             @csrf
                             @method('PUT')
-                            <div class="form-group">
-                                <label for="name">Name</label>
-                                <input type="text" name="name" id="name" class="form-control"
-                                    value="{{ old('name', $keyFeature->name) }}">
-                                @error('name')
-                                    <span class="text-danger">{{ $message }}</span>
-                                @enderror
-                            </div>
-                            <div class="form-group">
-                                <label for="description">Description</label>
-                                <textarea name="description" id="description" class="form-control">{{ old('description', $keyFeature->description) }}</textarea>
-                                @error('description')
-                                    <span class="text-danger">{{ $message }}</span>
-                                @enderror
-                            </div>
-                            <div class="form-group">
-                                <label for="image">Image</label>
-                                <input type="file" name="image" id="image" class="form-control">
-                                @error('image')
-                                    <span class="text-danger">{{ $message }}</span>
-                                @enderror
-                                @if ($keyFeature->image)
-                                    <img src="{{ asset('storage/key_features/' . $keyFeature->image) }}"
-                                        alt="{{ $keyFeature->name }}" width="100" class="mt-2">
-                                @endif
-                            </div>
-                            <button type="submit" class="btn btn-primary">Update</button>
+                            <x-admin.bootstrap.text-input name="name" label="Name" :value="$keyFeature->name" required />
+                            <x-admin.bootstrap.textarea name="description" label="Description" :value="$keyFeature->description" />
+                            <x-admin.bootstrap.file-input name="image" label="Image" :value="$keyFeature->image" />
+                            <x-admin.bootstrap.submit-button label="Update" />
                         </form>
                     </div>
                     <!-- /.card-body -->

--- a/resources/views/admin/key_features/index.blade.php
+++ b/resources/views/admin/key_features/index.blade.php
@@ -3,58 +3,44 @@
 @section('title', 'Index Key Features')
 @section('header-title', 'Index Key Features')
 
-
-
-
-
 @section('content')
     <div class="container-fluid">
         <div class="row">
             <div class="col-12">
                 <div class="card">
-                    <div class="card-header d-flex justify-content-between">
+                    <div class="card-header">
                         <h3 class="card-title">Key Features</h3>
-                        <a href="{{ route('admin.key-features.create') }}" class="btn btn-primary">Create Key Feature</a>
+                        <a href="{{ route('admin.key-features.create') }}" class="btn btn-primary float-right">Create New</a>
                     </div>
-                    <!-- /.card-header -->
                     <div class="card-body">
-                        <table id="example1" class="table table-bordered table-striped">
+                        <table class="table table-bordered">
                             <thead>
                                 <tr>
-                                    <th>#</th>
-                                    <th>Image</th>
                                     <th>Name</th>
                                     <th>Description</th>
-                                    <th>Action</th>
+                                    <th>Image</th>
+                                    <th>Actions</th>
                                 </tr>
                             </thead>
                             <tbody>
                                 @foreach ($keyFeatures as $keyFeature)
                                     <tr>
-                                        <td>{{ $loop->iteration }}</td>
-                                        <td>
-                                            <img src="{{ asset('storage/key_features/' . $keyFeature->image) }}"
-                                                alt="{{ $keyFeature->name }}" width="100">
-                                        </td>
                                         <td>{{ $keyFeature->name }}</td>
                                         <td>{{ $keyFeature->description }}</td>
                                         <td>
-                                            <a href="{{ route('admin.key-features.edit', $keyFeature->id) }}"
-                                                class="btn btn-primary">Edit</a>
-                                            <form action="{{ route('admin.key-features.destroy', $keyFeature->id) }}"
-                                                method="POST" class="d-inline">
-                                                @csrf
-                                                @method('DELETE')
-                                                <button type="submit" class="btn btn-danger"
-                                                    onclick="return confirm('Are you sure?')">Delete</button>
-                                            </form>
+                                            @if ($keyFeature->image)
+                                                <img src="{{ asset('storage/key_features/' . $keyFeature->image) }}" alt="{{ $keyFeature->name }}" width="100">
+                                            @endif
+                                        </td>
+                                        <td>
+                                            <a href="{{ route('admin.key-features.edit', $keyFeature) }}" class="btn btn-info btn-sm">Edit</a>
+                                            <x-admin.bootstrap.delete-button :route="route('admin.key-features.destroy', $keyFeature)" />
                                         </td>
                                     </tr>
                                 @endforeach
                             </tbody>
                         </table>
                     </div>
-                    <!-- /.card-body -->
                 </div>
             </div>
         </div>

--- a/resources/views/admin/layouts/app.blade.php
+++ b/resources/views/admin/layouts/app.blade.php
@@ -150,6 +150,7 @@
             <!-- Main Content -->
             <main class="flex-1 p-8 overflow-y-auto">
                 @include('admin.partials.breadcrumbs')
+                <x-admin.status-message />
                 @yield('content')
             </main>
         </div>

--- a/resources/views/admin/menus/create.blade.php
+++ b/resources/views/admin/menus/create.blade.php
@@ -7,18 +7,9 @@
 
     <form action="{{ route('admin.menus.store') }}" method="POST">
         @csrf
-        <div class="mb-3">
-            <label for="name" class="form-label">Name</label>
-            <input type="text" class="form-control" id="name" name="name" required>
-        </div>
-        <div class="mb-3">
-            <label for="route" class="form-label">Route</label>
-            <input type="text" class="form-control" id="route" name="route" required>
-        </div>
-        <div class="mb-3">
-            <label for="order" class="form-label">Order</label>
-            <input type="number" class="form-control" id="order" name="order" value="0" required>
-        </div>
-        <button type="submit" class="btn btn-primary">Create</button>
+        <x-admin.bootstrap.text-input name="name" label="Name" required />
+        <x-admin.bootstrap.text-input name="route" label="Route" required />
+        <x-admin.bootstrap.text-input name="order" label="Order" value="0" required />
+        <x-admin.bootstrap.submit-button label="Create" />
     </form>
 @endsection

--- a/resources/views/admin/menus/edit.blade.php
+++ b/resources/views/admin/menus/edit.blade.php
@@ -8,18 +8,9 @@
     <form action="{{ route('admin.menus.update', $menu) }}" method="POST">
         @csrf
         @method('PUT')
-        <div class="mb-3">
-            <label for="name" class="form-label">Name</label>
-            <input type="text" class="form-control" id="name" name="name" value="{{ $menu->name }}" required>
-        </div>
-        <div class="mb-3">
-            <label for="route" class="form-label">Route</label>
-            <input type="text" class="form-control" id="route" name="route" value="{{ $menu->route }}" required>
-        </div>
-        <div class="mb-3">
-            <label for="order" class="form-label">Order</label>
-            <input type="number" class="form-control" id="order" name="order" value="{{ $menu->order }}" required>
-        </div>
-        <button type="submit" class="btn btn-primary">Update</button>
+        <x-admin.bootstrap.text-input name="name" label="Name" :value="$menu->name" required />
+        <x-admin.bootstrap.text-input name="route" label="Route" :value="$menu->route" required />
+        <x-admin.bootstrap.text-input name="order" label="Order" :value="$menu->order" required />
+        <x-admin.bootstrap.submit-button label="Update" />
     </form>
 @endsection

--- a/resources/views/admin/menus/index.blade.php
+++ b/resources/views/admin/menus/index.blade.php
@@ -3,12 +3,11 @@
 @section('title', 'Menus')
 
 @section('content')
-    <div class="d-flex justify-content-between align-items-center">
-        <h1 class="h3">Menus</h1>
-        <a href="{{ route('admin.menus.create') }}" class="btn btn-primary">Create Menu</a>
-    </div>
+    <h1 class="h3">Menus</h1>
 
-    <table class="table table-bordered mt-3">
+    <a href="{{ route('admin.menus.create') }}" class="btn btn-primary mb-3">Create Menu</a>
+
+    <table class="table">
         <thead>
             <tr>
                 <th>Name</th>
@@ -25,12 +24,7 @@
                     <td>{{ $menu->order }}</td>
                     <td>
                         <a href="{{ route('admin.menus.edit', $menu) }}" class="btn btn-sm btn-primary">Edit</a>
-                        <form action="{{ route('admin.menus.destroy', $menu) }}" method="POST" class="d-inline">
-                            @csrf
-                            @method('DELETE')
-                            <button type="submit" class="btn btn-sm btn-danger"
-                                onclick="return confirm('Are you sure?')">Delete</button>
-                        </form>
+                        <x-admin.bootstrap.delete-button :route="route('admin.menus.destroy', $menu)" />
                     </td>
                 </tr>
             @endforeach

--- a/resources/views/admin/pages/about.blade.php
+++ b/resources/views/admin/pages/about.blade.php
@@ -3,10 +3,6 @@
 @section('title', 'About')
 @section('header-title', 'About')
 
-
-
-
-
 @section('content')
     <div class="container-fluid">
         <div class="row">
@@ -18,138 +14,71 @@
                     <div class="card-body">
                         <form action="{{ route('admin.pages.about.update') }}" method="POST" enctype="multipart/form-data">
                             @csrf
-                            <div class="form-group">
-                                <label for="page_title">Page Title</label>
-                                <input type="text" name="page_title" id="page_title" class="form-control" value="{{ $aboutSettings['page_title'] ?? '' }}">
-                            </div>
+                            <x-admin.bootstrap.text-input name="page_title" label="Page Title" :value="$aboutSettings['page_title'] ?? ''" />
                             <hr>
-                            <div class="form-group">
-                                <label for="about_us_title">Title</label>
-                                <input type="text" name="about_us_title" id="about_us_title" class="form-control" value="{{ $aboutSettings['about_us_title'] ?? '' }}">
-                            </div>
-                            <div class="form-group">
-                                <label for="about_us_description">Description</label>
-                                <textarea name="about_us_description" id="about_us_description" class="form-control" rows="5">{{ $aboutSettings['about_us_description'] ?? '' }}</textarea>
-                            </div>
-                            <div class="form-group">
-                                <label for="about_us_image">Image</label>
-                                <input type="file" name="about_us_image" id="about_us_image" class="form-control">
-                                @if(isset($aboutSettings['about_us_image']))
-                                    <img src="{{ asset('storage/' . $aboutSettings['about_us_image']) }}" alt="About Us Image" class="img-thumbnail mt-2" width="200">
-                                @endif
-                            </div>
+                            <x-admin.bootstrap.text-input name="about_us_title" label="Title" :value="$aboutSettings['about_us_title'] ?? ''" />
+                            <x-admin.bootstrap.textarea name="about_us_description" label="Description" :value="$aboutSettings['about_us_description'] ?? ''" />
+                            <x-admin.bootstrap.file-input name="about_us_image" label="Image" :value="$aboutSettings['about_us_image'] ?? ''" />
                             <hr>
                             <h4>Achievements</h4>
-                            <div class="form-group">
-                                <label for="achievement_title">Achievement Title</label>
-                                <input type="text" name="achievement_title" id="achievement_title" class="form-control" value="{{ $aboutSettings['achievement_title'] ?? '' }}">
-                            </div>
-                             <div class="form-group">
-                                <label for="achievement_description">Achievement Description</label>
-                                <input type="text" name="achievement_description" id="achievement_description" class="form-control" value="{{ $aboutSettings['achievement_description'] ?? '' }}">
-                            </div>
+                            <x-admin.bootstrap.text-input name="achievement_title" label="Achievement Title" :value="$aboutSettings['achievement_title'] ?? ''" />
+                            <x-admin.bootstrap.text-input name="achievement_description" label="Achievement Description" :value="$aboutSettings['achievement_description'] ?? ''" />
                             <div class="row">
                                 <div class="col-md-6">
-                                    <div class="form-group">
-                                        <label for="achievement_one_title">Achievement 1 Title</label>
-                                        <input type="text" name="achievement_one_title" id="achievement_one_title" class="form-control" value="{{ $aboutSettings['achievement_one_title'] ?? '' }}">
-                                    </div>
+                                    <x-admin.bootstrap.text-input name="achievement_one_title" label="Achievement 1 Title" :value="$aboutSettings['achievement_one_title'] ?? ''" />
                                 </div>
                                 <div class="col-md-6">
-                                    <div class="form-group">
-                                        <label for="achievement_one_value">Achievement 1 Value</label>
-                                        <input type="text" name="achievement_one_value" id="achievement_one_value" class="form-control" value="{{ $aboutSettings['achievement_one_value'] ?? '' }}">
-                                    </div>
-                                </div>
-                            </div>
-                             <div class="row">
-                                <div class="col-md-6">
-                                    <div class="form-group">
-                                        <label for="achievement_two_title">Achievement 2 Title</label>
-                                        <input type="text" name="achievement_two_title" id="achievement_two_title" class="form-control" value="{{ $aboutSettings['achievement_two_title'] ?? '' }}">
-                                    </div>
-                                </div>
-                                <div class="col-md-6">
-                                    <div class="form-group">
-                                        <label for="achievement_two_value">Achievement 2 Value</label>
-                                        <input type="text" name="achievement_two_value" id="achievement_two_value" class="form-control" value="{{ $aboutSettings['achievement_two_value'] ?? '' }}">
-                                    </div>
+                                    <x-admin.bootstrap.text-input name="achievement_one_value" label="Achievement 1 Value" :value="$aboutSettings['achievement_one_value'] ?? ''" />
                                 </div>
                             </div>
                             <div class="row">
                                 <div class="col-md-6">
-                                    <div class="form-group">
-                                        <label for="achievement_three_title">Achievement 3 Title</label>
-                                        <input type="text" name="achievement_three_title" id="achievement_three_title" class="form-control" value="{{ $aboutSettings['achievement_three_title'] ?? '' }}">
-                                    </div>
+                                    <x-admin.bootstrap.text-input name="achievement_two_title" label="Achievement 2 Title" :value="$aboutSettings['achievement_two_title'] ?? ''" />
                                 </div>
                                 <div class="col-md-6">
-                                    <div class="form-group">
-                                        <label for="achievement_three_value">Achievement 3 Value</label>
-                                        <input type="text" name="achievement_three_value" id="achievement_three_value" class="form-control" value="{{ $aboutSettings['achievement_three_value'] ?? '' }}">
-                                    </div>
+                                    <x-admin.bootstrap.text-input name="achievement_two_value" label="Achievement 2 Value" :value="$aboutSettings['achievement_two_value'] ?? ''" />
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-md-6">
+                                    <x-admin.bootstrap.text-input name="achievement_three_title" label="Achievement 3 Title" :value="$aboutSettings['achievement_three_title'] ?? ''" />
+                                </div>
+                                <div class="col-md-6">
+                                    <x-admin.bootstrap.text-input name="achievement_three_value" label="Achievement 3 Value" :value="$aboutSettings['achievement_three_value'] ?? ''" />
                                 </div>
                             </div>
                             <hr>
                             <h4>Journey</h4>
-                            <div class="form-group">
-                                <label for="journey_title">Journey Title</label>
-                                <input type="text" name="journey_title" id="journey_title" class="form-control" value="{{ $aboutSettings['journey_title'] ?? '' }}">
-                            </div>
-                             <div class="form-group">
-                                <label for="journey_description">Journey Description</label>
-                                <input type="text" name="journey_description" id="journey_description" class="form-control" value="{{ $aboutSettings['journey_description'] ?? '' }}">
-                            </div>
+                            <x-admin.bootstrap.text-input name="journey_title" label="Journey Title" :value="$aboutSettings['journey_title'] ?? ''" />
+                            <x-admin.bootstrap.text-input name="journey_description" label="Journey Description" :value="$aboutSettings['journey_description'] ?? ''" />
                             <div class="row">
                                 <div class="col-md-6">
-                                    <div class="form-group">
-                                        <label for="journey_one_title">Journey 1 Title</label>
-                                        <input type="text" name="journey_one_title" id="journey_one_title" class="form-control" value="{{ $aboutSettings['journey_one_title'] ?? '' }}">
-                                    </div>
+                                    <x-admin.bootstrap.text-input name="journey_one_title" label="Journey 1 Title" :value="$aboutSettings['journey_one_title'] ?? ''" />
                                 </div>
                                 <div class="col-md-6">
-                                    <div class="form-group">
-                                        <label for="journey_one_description">Journey 1 Description</label>
-                                        <input type="text" name="journey_one_description" id="journey_one_description" class="form-control" value="{{ $aboutSettings['journey_one_description'] ?? '' }}">
-                                    </div>
+                                    <x-admin.bootstrap.text-input name="journey_one_description" label="Journey 1 Description" :value="$aboutSettings['journey_one_description'] ?? ''" />
                                 </div>
                             </div>
                             <div class="row">
                                 <div class="col-md-6">
-                                    <div class="form-group">
-                                        <label for="journey_two_title">Journey 2 Title</label>
-                                        <input type="text" name="journey_two_title" id="journey_two_title" class="form-control" value="{{ $aboutSettings['journey_two_title'] ?? '' }}">
-                                    </div>
+                                    <x-admin.bootstrap.text-input name="journey_two_title" label="Journey 2 Title" :value="$aboutSettings['journey_two_title'] ?? ''" />
                                 </div>
                                 <div class="col-md-6">
-                                    <div class="form-group">
-                                        <label for="journey_two_description">Journey 2 Description</label>
-                                        <input type="text" name="journey_two_description" id="journey_two_description" class="form-control" value="{{ $aboutSettings['journey_two_description'] ?? '' }}">
-                                    </div>
+                                    <x-admin.bootstrap.text-input name="journey_two_description" label="Journey 2 Description" :value="$aboutSettings['journey_two_description'] ?? ''" />
                                 </div>
                             </div>
                             <div class="row">
                                 <div class="col-md-6">
-                                    <div class="form-group">
-                                        <label for="journey_three_title">Journey 3 Title</label>
-                                        <input type="text" name="journey_three_title" id="journey_three_title" class="form-control" value="{{ $aboutSettings['journey_three_title'] ?? '' }}">
-                                    </div>
+                                    <x-admin.bootstrap.text-input name="journey_three_title" label="Journey 3 Title" :value="$aboutSettings['journey_three_title'] ?? ''" />
                                 </div>
                                 <div class="col-md-6">
-                                    <div class="form-group">
-                                        <label for="journey_three_description">Journey 3 Description</label>
-                                        <input type="text" name="journey_three_description" id="journey_three_description" class="form-control" value="{{ $aboutSettings['journey_three_description'] ?? '' }}">
-                                    </div>
+                                    <x-admin.bootstrap.text-input name="journey_three_description" label="Journey 3 Description" :value="$aboutSettings['journey_three_description'] ?? ''" />
                                 </div>
                             </div>
-                             <hr>
+                            <hr>
                             <h4>Our Team</h4>
-                             <div class="form-group">
-                                <label for="team_title">Team Title</label>
-                                <input type="text" name="team_title" id="team_title" class="form-control" value="{{ $aboutSettings['team_title'] ?? '' }}">
-                            </div>
-
-                            <button type="submit" class="btn btn-primary">Update Settings</button>
+                            <x-admin.bootstrap.text-input name="team_title" label="Team Title" :value="$aboutSettings['team_title'] ?? ''" />
+                            <x-admin.bootstrap.submit-button label="Update Settings" />
                         </form>
                     </div>
                 </div>

--- a/resources/views/admin/price-plans/create.blade.php
+++ b/resources/views/admin/price-plans/create.blade.php
@@ -3,46 +3,21 @@
 @section('title', 'Create Price Plans')
 @section('header-title', 'Create Price Plans')
 
-
-
-
-
 @section('content')
     <h1 class="text-2xl font-bold mb-4">Create Price Plan</h1>
 
     <form action="{{ route('admin.price-plans.store') }}" method="POST">
         @csrf
-        <div class="mb-4">
-            <label for="name" class="block text-gray-700">Name</label>
-            <input type="text" name="name" id="name" class="w-full px-3 py-2 border rounded-md" value="{{ old('name') }}" required>
-            @error('name')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="type" class="block text-gray-700">Type</label>
-            <select name="type" id="type" class="w-full px-3 py-2 border rounded-md" required>
-                <option value="fixed" {{ old('type') === 'fixed' ? 'selected' : '' }}>Fixed</option>
-                <option value="free" {{ old('type') === 'free' ? 'selected' : '' }}>Free</option>
-                <option value="custom" {{ old('type') === 'custom' ? 'selected' : '' }}>Custom</option>
-            </select>
-            @error('type')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4" id="price-container">
-            <label for="price" class="block text-gray-700">Price</label>
-            <input type="number" name="price" id="price" class="w-full px-3 py-2 border rounded-md" value="{{ old('price') }}">
-            @error('price')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
+        <x-admin.text-input name="name" label="Name" required />
+        <x-admin.select name="type" label="Type" :options="['fixed' => 'Fixed', 'free' => 'Free', 'custom' => 'Custom']" required />
+        <div id="price-container">
+            <x-admin.text-input name="price" label="Price" />
         </div>
         <div class="mb-4">
             <label class="block text-gray-700">Features</label>
             @foreach ($features as $feature)
                 <div class="flex items-center">
-                    <input type="checkbox" name="features[{{ $feature->id }}][id]" value="{{ $feature->id }}" class="mr-2">
-                    <label>{{ $feature->name }}</label>
+                    <x-admin.checkbox name="features[{{ $feature->id }}][id]" :value="$feature->id" :label="$feature->name" />
                     <div class="ml-4">
                         <label class="mr-2">
                             <input type="radio" name="features[{{ $feature->id }}][is_active]" value="1" class="mr-1">
@@ -56,16 +31,7 @@
                 </div>
             @endforeach
         </div>
-        <div class="mb-4">
-            <label for="planable_type" class="block text-gray-700">Planable Type</label>
-            <select name="planable_type" id="planable_type" class="w-full px-3 py-2 border rounded-md" required>
-                <option value="App\Models\ServiceType">Service Type</option>
-                <option value="App\Models\Software">Software</option>
-            </select>
-            @error('planable_type')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
+        <x-admin.select name="planable_type" label="Planable Type" :options="['App\Models\ServiceType' => 'Service Type', 'App\Models\Software' => 'Software']" required />
         <div class="mb-4">
             <label for="planable_id" class="block text-gray-700">Planable</label>
             <select name="planable_id" id="planable_id" class="w-full px-3 py-2 border rounded-md" required>
@@ -75,7 +41,7 @@
                 <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
             @enderror
         </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create</button>
+        <x-admin.submit-button label="Create" />
     </form>
 
     <script>

--- a/resources/views/admin/price-plans/edit.blade.php
+++ b/resources/views/admin/price-plans/edit.blade.php
@@ -3,40 +3,16 @@
 @section('title', 'Edit Price Plans')
 @section('header-title', 'Edit Price Plans')
 
-
-
-
-
 @section('content')
     <h1 class="text-2xl font-bold mb-4">Edit Price Plan</h1>
 
     <form action="{{ route('admin.price-plans.update', $pricePlan) }}" method="POST">
         @csrf
         @method('PUT')
-        <div class="mb-4">
-            <label for="name" class="block text-gray-700">Name</label>
-            <input type="text" name="name" id="name" class="w-full px-3 py-2 border rounded-md" value="{{ old('name', $pricePlan->name) }}" required>
-            @error('name')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="type" class="block text-gray-700">Type</label>
-            <select name="type" id="type" class="w-full px-3 py-2 border rounded-md" required>
-                <option value="fixed" {{ old('type', $pricePlan->type) === 'fixed' ? 'selected' : '' }}>Fixed</option>
-                <option value="free" {{ old('type', $pricePlan->type) === 'free' ? 'selected' : '' }}>Free</option>
-                <option value="custom" {{ old('type', $pricePlan->type) === 'custom' ? 'selected' : '' }}>Custom</option>
-            </select>
-            @error('type')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4" id="price-container">
-            <label for="price" class="block text-gray-700">Price</label>
-            <input type="number" name="price" id="price" class="w-full px-3 py-2 border rounded-md" value="{{ old('price', $pricePlan->price) }}">
-            @error('price')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
+        <x-admin.text-input name="name" label="Name" :value="$pricePlan->name" required />
+        <x-admin.select name="type" label="Type" :options="['fixed' => 'Fixed', 'free' => 'Free', 'custom' => 'Custom']" :value="$pricePlan->type" required />
+        <div id="price-container">
+            <x-admin.text-input name="price" label="Price" :value="$pricePlan->price" />
         </div>
         <div class="mb-4">
             <label class="block text-gray-700">Features</label>
@@ -46,8 +22,7 @@
                     $isActive = $planFeature ? $planFeature->pivot->is_active : false;
                 @endphp
                 <div class="flex items-center">
-                    <input type="checkbox" name="features[{{ $feature->id }}][id]" value="{{ $feature->id }}" class="mr-2" @if($planFeature) checked @endif>
-                    <label>{{ $feature->name }}</label>
+                    <x-admin.checkbox name="features[{{ $feature->id }}][id]" :value="$feature->id" :label="$feature->name" :checked="!!$planFeature" />
                     <div class="ml-4">
                         <label class="mr-2">
                             <input type="radio" name="features[{{ $feature->id }}][is_active]" value="1" class="mr-1" @if($isActive) checked @endif>
@@ -61,16 +36,7 @@
                 </div>
             @endforeach
         </div>
-        <div class="mb-4">
-            <label for="planable_type" class="block text-gray-700">Planable Type</label>
-            <select name="planable_type" id="planable_type" class="w-full px-3 py-2 border rounded-md" required>
-                <option value="App\Models\ServiceType" @if($pricePlan->planable_type == 'App\Models\ServiceType') selected @endif>Service Type</option>
-                <option value="App\Models\Software" @if($pricePlan->planable_type == 'App\Models\Software') selected @endif>Software</option>
-            </select>
-            @error('planable_type')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
+        <x-admin.select name="planable_type" label="Planable Type" :options="['App\Models\ServiceType' => 'Service Type', 'App\Models\Software' => 'Software']" :value="$pricePlan->planable_type" required />
         <div class="mb-4">
             <label for="planable_id" class="block text-gray-700">Planable</label>
             <select name="planable_id" id="planable_id" class="w-full px-3 py-2 border rounded-md" required>
@@ -80,7 +46,7 @@
                 <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
             @enderror
         </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Update</button>
+        <x-admin.submit-button label="Update" />
     </form>
 
     <script>

--- a/resources/views/admin/price-plans/index.blade.php
+++ b/resources/views/admin/price-plans/index.blade.php
@@ -3,21 +3,11 @@
 @section('title', 'Index Price Plans')
 @section('header-title', 'Index Price Plans')
 
-
-
-
-
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Price Plans</h1>
         <a href="{{ route('admin.price-plans.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
     </div>
-
-    @if (session('success'))
-        <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <span class="block sm:inline">{{ session('success') }}</span>
-        </div>
-    @endif
 
     <table class="w-full bg-white shadow-md rounded-lg">
         <thead>
@@ -34,17 +24,13 @@
             @foreach ($pricePlans as $pricePlan)
                 <tr>
                     <td class="border px-4 py-2">{{ $pricePlan->name }}</td>
-                    <td class="border px-4 py-2">{{ ucfirst($pricePlan->type) }}</td>
-                    <td class="border px-4 py-2">{{ $pricePlan->price ? $pricePlan->price : '-' }}</td>
+                    <td class="border px-4 py-2">{{ $pricePlan->type }}</td>
+                    <td class="border px-4 py-2">{{ $pricePlan->price }}</td>
                     <td class="border px-4 py-2">{{ $pricePlan->planable_type }}</td>
                     <td class="border px-4 py-2">{{ $pricePlan->planable->name }}</td>
                     <td class="border px-4 py-2">
                         <a href="{{ route('admin.price-plans.edit', $pricePlan) }}" class="text-blue-500 hover:underline">Edit</a>
-                        <form action="{{ route('admin.price-plans.destroy', $pricePlan) }}" method="POST" class="inline-block ml-2">
-                            @csrf
-                            @method('DELETE')
-                            <button type="submit" class="text-red-500 hover:underline" onclick="return confirm('Are you sure?')">Delete</button>
-                        </form>
+                        <x-admin.delete-button :route="route('admin.price-plans.destroy', $pricePlan)" />
                     </td>
                 </tr>
             @endforeach

--- a/resources/views/admin/project-categories/create.blade.php
+++ b/resources/views/admin/project-categories/create.blade.php
@@ -3,29 +3,13 @@
 @section('title', 'Create Project Categories')
 @section('header-title', 'Create Project Categories')
 
-
-
-
-
 @section('content')
     <h1 class="text-2xl font-bold mb-4">Create Project Category</h1>
 
     <form action="{{ route('admin.project-categories.store') }}" method="POST">
         @csrf
-        <div class="mb-4">
-            <label for="name" class="block text-gray-700">Name</label>
-            <input type="text" name="name" id="name" class="w-full px-3 py-2 border rounded-md" value="{{ old('name') }}" required>
-            @error('name')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="slug" class="block text-gray-700">Slug</label>
-            <input type="text" name="slug" id="slug" class="w-full px-3 py-2 border rounded-md" value="{{ old('slug') }}" required>
-            @error('slug')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create</button>
+        <x-admin.text-input name="name" label="Name" required />
+        <x-admin.text-input name="slug" label="Slug" required />
+        <x-admin.submit-button label="Create" />
     </form>
 @endsection

--- a/resources/views/admin/project-categories/edit.blade.php
+++ b/resources/views/admin/project-categories/edit.blade.php
@@ -3,30 +3,14 @@
 @section('title', 'Edit Project Categories')
 @section('header-title', 'Edit Project Categories')
 
-
-
-
-
 @section('content')
     <h1 class="text-2xl font-bold mb-4">Edit Project Category</h1>
 
     <form action="{{ route('admin.project-categories.update', $projectCategory) }}" method="POST">
         @csrf
         @method('PUT')
-        <div class="mb-4">
-            <label for="name" class="block text-gray-700">Name</label>
-            <input type="text" name="name" id="name" class="w-full px-3 py-2 border rounded-md" value="{{ old('name', $projectCategory->name) }}" required>
-            @error('name')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="slug" class="block text-gray-700">Slug</label>
-            <input type="text" name="slug" id="slug" class="w-full px-3 py-2 border rounded-md" value="{{ old('slug', $projectCategory->slug) }}" required>
-            @error('slug')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Update</button>
+        <x-admin.text-input name="name" label="Name" :value="$projectCategory->name" required />
+        <x-admin.text-input name="slug" label="Slug" :value="$projectCategory->slug" required />
+        <x-admin.submit-button label="Update" />
     </form>
 @endsection

--- a/resources/views/admin/project-categories/index.blade.php
+++ b/resources/views/admin/project-categories/index.blade.php
@@ -3,21 +3,11 @@
 @section('title', 'Index Project Categories')
 @section('header-title', 'Index Project Categories')
 
-
-
-
-
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Project Categories</h1>
         <a href="{{ route('admin.project-categories.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
     </div>
-
-    @if (session('success'))
-        <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <span class="block sm:inline">{{ session('success') }}</span>
-        </div>
-    @endif
 
     <table class="w-full bg-white shadow-md rounded-lg">
         <thead>
@@ -34,11 +24,7 @@
                     <td class="border px-4 py-2">{{ $category->slug }}</td>
                     <td class="border px-4 py-2">
                         <a href="{{ route('admin.project-categories.edit', $category) }}" class="text-blue-500 hover:underline">Edit</a>
-                        <form action="{{ route('admin.project-categories.destroy', $category) }}" method="POST" class="inline-block ml-2">
-                            @csrf
-                            @method('DELETE')
-                            <button type="submit" class="text-red-500 hover:underline" onclick="return confirm('Are you sure?')">Delete</button>
-                        </form>
+                        <x-admin.delete-button :route="route('admin.project-categories.destroy', $category)" />
                     </td>
                 </tr>
             @endforeach

--- a/resources/views/admin/projects/create.blade.php
+++ b/resources/views/admin/projects/create.blade.php
@@ -3,47 +3,15 @@
 @section('title', 'Create Projects')
 @section('header-title', 'Create Projects')
 
-
-
-
-
 @section('content')
     <h1 class="text-2xl font-bold mb-4">Create Project</h1>
 
     <form action="{{ route('admin.projects.store') }}" method="POST" enctype="multipart/form-data">
         @csrf
-        <div class="mb-4">
-            <label for="title" class="block text-gray-700">Title</label>
-            <input type="text" name="title" id="title" class="w-full px-3 py-2 border rounded-md" value="{{ old('title') }}" required>
-            @error('title')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="slug" class="block text-gray-700">Slug</label>
-            <input type="text" name="slug" id="slug" class="w-full px-3 py-2 border rounded-md" value="{{ old('slug') }}" required>
-            @error('slug')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="project_category_id" class="block text-gray-700">Category</label>
-            <select name="project_category_id" id="project_category_id" class="w-full px-3 py-2 border rounded-md" required>
-                @foreach ($categories as $category)
-                    <option value="{{ $category->id }}">{{ $category->name }}</option>
-                @endforeach
-            </select>
-            @error('project_category_id')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="thumbnail" class="block text-gray-700">Thumbnail</label>
-            <input type="file" name="thumbnail" id="thumbnail" class="w-full px-3 py-2 border rounded-md">
-            @error('thumbnail')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create</button>
+        <x-admin.text-input name="title" label="Title" required />
+        <x-admin.text-input name="slug" label="Slug" required />
+        <x-admin.select name="project_category_id" label="Category" :options="$categories->pluck('name', 'id')" required />
+        <x-admin.file-input name="thumbnail" label="Thumbnail" />
+        <x-admin.submit-button label="Create" />
     </form>
 @endsection

--- a/resources/views/admin/projects/edit.blade.php
+++ b/resources/views/admin/projects/edit.blade.php
@@ -3,51 +3,16 @@
 @section('title', 'Edit Projects')
 @section('header-title', 'Edit Projects')
 
-
-
-
-
 @section('content')
     <h1 class="text-2xl font-bold mb-4">Edit Project</h1>
 
     <form action="{{ route('admin.projects.update', $project) }}" method="POST" enctype="multipart/form-data">
         @csrf
         @method('PUT')
-        <div class="mb-4">
-            <label for="title" class="block text-gray-700">Title</label>
-            <input type="text" name="title" id="title" class="w-full px-3 py-2 border rounded-md" value="{{ old('title', $project->title) }}" required>
-            @error('title')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="slug" class="block text-gray-700">Slug</label>
-            <input type="text" name="slug" id="slug" class="w-full px-3 py-2 border rounded-md" value="{{ old('slug', $project->slug) }}" required>
-            @error('slug')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="project_category_id" class="block text-gray-700">Category</label>
-            <select name="project_category_id" id="project_category_id" class="w-full px-3 py-2 border rounded-md" required>
-                @foreach ($categories as $category)
-                    <option value="{{ $category->id }}" @selected($project->project_category_id == $category->id)>{{ $category->name }}</option>
-                @endforeach
-            </select>
-            @error('project_category_id')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="thumbnail" class="block text-gray-700">Thumbnail</label>
-            <input type="file" name="thumbnail" id="thumbnail" class="w-full px-3 py-2 border rounded-md">
-            @if ($project->thumbnail)
-                <img src="{{ asset('storage/' . $project->thumbnail) }}" alt="{{ $project->title }}" class="h-16 w-16 object-cover mt-2">
-            @endif
-            @error('thumbnail')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Update</button>
+        <x-admin.text-input name="title" label="Title" :value="$project->title" required />
+        <x-admin.text-input name="slug" label="Slug" :value="$project->slug" required />
+        <x-admin.select name="project_category_id" label="Category" :options="$categories->pluck('name', 'id')" :value="$project->project_category_id" required />
+        <x-admin.file-input name="thumbnail" label="Thumbnail" :value="$project->thumbnail" />
+        <x-admin.submit-button label="Update" />
     </form>
 @endsection

--- a/resources/views/admin/projects/index.blade.php
+++ b/resources/views/admin/projects/index.blade.php
@@ -3,21 +3,11 @@
 @section('title', 'Index Projects')
 @section('header-title', 'Index Projects')
 
-
-
-
-
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Projects</h1>
         <a href="{{ route('admin.projects.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
     </div>
-
-    @if (session('success'))
-        <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <span class="block sm:inline">{{ session('success') }}</span>
-        </div>
-    @endif
 
     <table class="w-full bg-white shadow-md rounded-lg">
         <thead>
@@ -32,7 +22,7 @@
             @foreach ($projects as $project)
                 <tr>
                     <td class="border px-4 py-2">{{ $project->title }}</td>
-                    <td class="border px-4 py-2">{{ $project->category->name }}</td>
+                    <td class="border px-4 py-2">{{ $project->project_category->name }}</td>
                     <td class="border px-4 py-2">
                         @if ($project->thumbnail)
                             <img src="{{ asset('storage/' . $project->thumbnail) }}" alt="{{ $project->title }}" class="h-16 w-16 object-cover">
@@ -40,11 +30,7 @@
                     </td>
                     <td class="border px-4 py-2">
                         <a href="{{ route('admin.projects.edit', $project) }}" class="text-blue-500 hover:underline">Edit</a>
-                        <form action="{{ route('admin.projects.destroy', $project) }}" method="POST" class="inline-block ml-2">
-                            @csrf
-                            @method('DELETE')
-                            <button type="submit" class="text-red-500 hover:underline" onclick="return confirm('Are you sure?')">Delete</button>
-                        </form>
+                        <x-admin.delete-button :route="route('admin.projects.destroy', $project)" />
                     </td>
                 </tr>
             @endforeach

--- a/resources/views/admin/service-categories/create.blade.php
+++ b/resources/views/admin/service-categories/create.blade.php
@@ -3,29 +3,13 @@
 @section('title', 'Create Service Categories')
 @section('header-title', 'Create Service Categories')
 
-
-
-
-
 @section('content')
     <h1 class="text-2xl font-bold mb-4">Create Service Category</h1>
 
     <form action="{{ route('admin.service-categories.store') }}" method="POST">
         @csrf
-        <div class="mb-4">
-            <label for="name" class="block text-gray-700">Name</label>
-            <input type="text" name="name" id="name" class="w-full px-3 py-2 border rounded-md" value="{{ old('name') }}" required>
-            @error('name')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="slug" class="block text-gray-700">Slug</label>
-            <input type="text" name="slug" id="slug" class="w-full px-3 py-2 border rounded-md" value="{{ old('slug') }}" required>
-            @error('slug')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create</button>
+        <x-admin.text-input name="name" label="Name" required />
+        <x-admin.text-input name="slug" label="Slug" required />
+        <x-admin.submit-button label="Create" />
     </form>
 @endsection

--- a/resources/views/admin/service-categories/edit.blade.php
+++ b/resources/views/admin/service-categories/edit.blade.php
@@ -3,30 +3,14 @@
 @section('title', 'Edit Service Categories')
 @section('header-title', 'Edit Service Categories')
 
-
-
-
-
 @section('content')
     <h1 class="text-2xl font-bold mb-4">Edit Service Category</h1>
 
     <form action="{{ route('admin.service-categories.update', $serviceCategory) }}" method="POST">
         @csrf
         @method('PUT')
-        <div class="mb-4">
-            <label for="name" class="block text-gray-700">Name</label>
-            <input type="text" name="name" id="name" class="w-full px-3 py-2 border rounded-md" value="{{ old('name', $serviceCategory->name) }}" required>
-            @error('name')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="slug" class="block text-gray-700">Slug</label>
-            <input type="text" name="slug" id="slug" class="w-full px-3 py-2 border rounded-md" value="{{ old('slug', $serviceCategory->slug) }}" required>
-            @error('slug')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Update</button>
+        <x-admin.text-input name="name" label="Name" :value="$serviceCategory->name" required />
+        <x-admin.text-input name="slug" label="Slug" :value="$serviceCategory->slug" required />
+        <x-admin.submit-button label="Update" />
     </form>
 @endsection

--- a/resources/views/admin/service-categories/index.blade.php
+++ b/resources/views/admin/service-categories/index.blade.php
@@ -3,21 +3,11 @@
 @section('title', 'Index Service Categories')
 @section('header-title', 'Index Service Categories')
 
-
-
-
-
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Service Categories</h1>
         <a href="{{ route('admin.service-categories.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
     </div>
-
-    @if (session('success'))
-        <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <span class="block sm:inline">{{ session('success') }}</span>
-        </div>
-    @endif
 
     <table class="w-full bg-white shadow-md rounded-lg">
         <thead>
@@ -34,11 +24,7 @@
                     <td class="border px-4 py-2">{{ $category->slug }}</td>
                     <td class="border px-4 py-2">
                         <a href="{{ route('admin.service-categories.edit', $category) }}" class="text-blue-500 hover:underline">Edit</a>
-                        <form action="{{ route('admin.service-categories.destroy', $category) }}" method="POST" class="inline-block ml-2">
-                            @csrf
-                            @method('DELETE')
-                            <button type="submit" class="text-red-500 hover:underline" onclick="return confirm('Are you sure?')">Delete</button>
-                        </form>
+                        <x-admin.delete-button :route="route('admin.service-categories.destroy', $category)" />
                     </td>
                 </tr>
             @endforeach

--- a/resources/views/admin/service-types/create.blade.php
+++ b/resources/views/admin/service-types/create.blade.php
@@ -3,33 +3,13 @@
 @section('title', 'Create Service Types')
 @section('header-title', 'Create Service Types')
 
-
-
-
-
 @section('content')
     <h1 class="text-2xl font-bold mb-4">Create Service Type</h1>
 
     <form action="{{ route('admin.service-types.store') }}" method="POST">
         @csrf
-        <div class="mb-4">
-            <label for="name" class="block text-gray-700">Name</label>
-            <input type="text" name="name" id="name" class="w-full px-3 py-2 border rounded-md" value="{{ old('name') }}" required>
-            @error('name')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="service_id" class="block text-gray-700">Service</label>
-            <select name="service_id" id="service_id" class="w-full px-3 py-2 border rounded-md" required>
-                @foreach ($services as $service)
-                    <option value="{{ $service->id }}">{{ $service->name }}</option>
-                @endforeach
-            </select>
-            @error('service_id')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create</button>
+        <x-admin.text-input name="name" label="Name" required />
+        <x-admin.select name="service_id" label="Service" :options="$services->pluck('name', 'id')" required />
+        <x-admin.submit-button label="Create" />
     </form>
 @endsection

--- a/resources/views/admin/service-types/edit.blade.php
+++ b/resources/views/admin/service-types/edit.blade.php
@@ -3,34 +3,14 @@
 @section('title', 'Edit Service Types')
 @section('header-title', 'Edit Service Types')
 
-
-
-
-
 @section('content')
     <h1 class="text-2xl font-bold mb-4">Edit Service Type</h1>
 
     <form action="{{ route('admin.service-types.update', $serviceType) }}" method="POST">
         @csrf
         @method('PUT')
-        <div class="mb-4">
-            <label for="name" class="block text-gray-700">Name</label>
-            <input type="text" name="name" id="name" class="w-full px-3 py-2 border rounded-md" value="{{ old('name', $serviceType->name) }}" required>
-            @error('name')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="service_id" class="block text-gray-700">Service</label>
-            <select name="service_id" id="service_id" class="w-full px-3 py-2 border rounded-md" required>
-                @foreach ($services as $service)
-                    <option value="{{ $service->id }}" @if($service->id == $serviceType->service_id) selected @endif>{{ $service->name }}</option>
-                @endforeach
-            </select>
-            @error('service_id')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Update</button>
+        <x-admin.text-input name="name" label="Name" :value="$serviceType->name" required />
+        <x-admin.select name="service_id" label="Service" :options="$services->pluck('name', 'id')" :value="$serviceType->service_id" required />
+        <x-admin.submit-button label="Update" />
     </form>
 @endsection

--- a/resources/views/admin/service-types/index.blade.php
+++ b/resources/views/admin/service-types/index.blade.php
@@ -3,21 +3,11 @@
 @section('title', 'Index Service Types')
 @section('header-title', 'Index Service Types')
 
-
-
-
-
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Service Types</h1>
         <a href="{{ route('admin.service-types.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
     </div>
-
-    @if (session('success'))
-        <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <span class="block sm:inline">{{ session('success') }}</span>
-        </div>
-    @endif
 
     <table class="w-full bg-white shadow-md rounded-lg">
         <thead>
@@ -34,11 +24,7 @@
                     <td class="border px-4 py-2">{{ $serviceType->service->name }}</td>
                     <td class="border px-4 py-2">
                         <a href="{{ route('admin.service-types.edit', $serviceType) }}" class="text-blue-500 hover:underline">Edit</a>
-                        <form action="{{ route('admin.service-types.destroy', $serviceType) }}" method="POST" class="inline-block ml-2">
-                            @csrf
-                            @method('DELETE')
-                            <button type="submit" class="text-red-500 hover:underline" onclick="return confirm('Are you sure?')">Delete</button>
-                        </form>
+                        <x-admin.delete-button :route="route('admin.service-types.destroy', $serviceType)" />
                     </td>
                 </tr>
             @endforeach

--- a/resources/views/admin/services/create.blade.php
+++ b/resources/views/admin/services/create.blade.php
@@ -3,54 +3,16 @@
 @section('title', 'Create Services')
 @section('header-title', 'Create Services')
 
-
-
-
-
 @section('content')
     <h1 class="text-2xl font-bold mb-4">Create Service</h1>
 
     <form action="{{ route('admin.services.store') }}" method="POST" enctype="multipart/form-data">
         @csrf
-        <div class="mb-4">
-            <label for="name" class="block text-gray-700">Name</label>
-            <input type="text" name="name" id="name" class="w-full px-3 py-2 border rounded-md" value="{{ old('name') }}" required>
-            @error('name')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="slug" class="block text-gray-700">Slug</label>
-            <input type="text" name="slug" id="slug" class="w-full px-3 py-2 border rounded-md" value="{{ old('slug') }}" required>
-            @error('slug')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="service_category_id" class="block text-gray-700">Category</label>
-            <select name="service_category_id" id="service_category_id" class="w-full px-3 py-2 border rounded-md" required>
-                @foreach ($categories as $category)
-                    <option value="{{ $category->id }}">{{ $category->name }}</option>
-                @endforeach
-            </select>
-            @error('service_category_id')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="description" class="block text-gray-700">Description</label>
-            <textarea name="description" id="description" class="w-full px-3 py-2 border rounded-md">{{ old('description') }}</textarea>
-            @error('description')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="image" class="block text-gray-700">Image</label>
-            <input type="file" name="image" id="image" class="w-full px-3 py-2 border rounded-md">
-            @error('image')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create</button>
+        <x-admin.text-input name="name" label="Name" required />
+        <x-admin.text-input name="slug" label="Slug" required />
+        <x-admin.select name="service_category_id" label="Category" :options="$categories->pluck('name', 'id')" required />
+        <x-admin.textarea name="description" label="Description" />
+        <x-admin.file-input name="image" label="Image" />
+        <x-admin.submit-button label="Create" />
     </form>
 @endsection

--- a/resources/views/admin/services/edit.blade.php
+++ b/resources/views/admin/services/edit.blade.php
@@ -3,59 +3,18 @@
 @section('title', 'Edit Services')
 @section('header-title', 'Edit Services')
 
-
-
-
-
 @section('content')
     <h1 class="text-2xl font-bold mb-4">Edit Service</h1>
 
     <form action="{{ route('admin.services.update', $service) }}" method="POST" enctype="multipart/form-data">
         @csrf
         @method('PUT')
-        <div class="mb-4">
-            <label for="name" class="block text-gray-700">Name</label>
-            <input type="text" name="name" id="name" class="w-full px-3 py-2 border rounded-md" value="{{ old('name', $service->name) }}" required>
-            @error('name')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="slug" class="block text-gray-700">Slug</label>
-            <input type="text" name="slug" id="slug" class="w-full px-3 py-2 border rounded-md" value="{{ old('slug', $service->slug) }}" required>
-            @error('slug')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="service_category_id" class="block text-gray-700">Category</label>
-            <select name="service_category_id" id="service_category_id" class="w-full px-3 py-2 border rounded-md" required>
-                @foreach ($categories as $category)
-                    <option value="{{ $category->id }}" @selected($service->service_category_id == $category->id)>{{ $category->name }}</option>
-                @endforeach
-            </select>
-            @error('service_category_id')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="description" class="block text-gray-700">Description</label>
-            <textarea name="description" id="description" class="w-full px-3 py-2 border rounded-md">{{ old('description', $service->description) }}</textarea>
-            @error('description')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="image" class="block text-gray-700">Image</label>
-            <input type="file" name="image" id="image" class="w-full px-3 py-2 border rounded-md">
-            @if ($service->image)
-                <img src="{{ asset('storage/' . $service->image) }}" alt="{{ $service->name }}" class="h-16 w-16 object-cover mt-2">
-            @endif
-            @error('image')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Update</button>
+        <x-admin.text-input name="name" label="Name" :value="$service->name" required />
+        <x-admin.text-input name="slug" label="Slug" :value="$service->slug" required />
+        <x-admin.select name="service_category_id" label="Category" :options="$categories->pluck('name', 'id')" :value="$service->service_category_id" required />
+        <x-admin.textarea name="description" label="Description" :value="$service->description" />
+        <x-admin.file-input name="image" label="Image" :value="$service->image" />
+        <x-admin.submit-button label="Update" />
     </form>
 
     <div class="mt-8">

--- a/resources/views/admin/services/index.blade.php
+++ b/resources/views/admin/services/index.blade.php
@@ -3,58 +3,18 @@
 @section('title', 'Index Services')
 @section('header-title', 'Index Services')
 
-
-
-
-
 @section('content')
-<div class="flex justify-between items-center mb-4">
-    <h1 class="text-2xl font-bold">Services</h1>
-    <a href="{{ route('admin.services.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
-</div>
+    <div class="flex justify-between items-center mb-4">
+        <h1 class="text-2xl font-bold">Services</h1>
+        <a href="{{ route('admin.services.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
+    </div>
 
-@if (session('success'))
-<div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4" role="alert">
-    <span class="block sm:inline">{{ session('success') }}</span>
-</div>
-@endif
+    @if (session('success'))
+        <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4" role="alert">
+            <span class="block sm:inline">{{ session('success') }}</span>
+        </div>
+    @endif
 
-<<<<<<< HEAD
-<table class="w-full bg-white shadow-md rounded-lg">
-    <thead>
-        <tr class="bg-gray-200">
-            <th class="px-4 py-2">Name</th>
-            <th class="px-4 py-2">Category</th>
-            <th class="px-4 py-2">Image</th>
-            <th class="px-4 py-2">Actions</th>
-        </tr>
-    </thead>
-    <tbody>
-        @foreach ($services as $service)
-        <tr>
-            <td class="border px-4 py-2">{{ $service->name }}</td>
-            <td class="border px-4 py-2">{{ $service->service_category->name }}</td>
-            <td class="border px-4 py-2">
-                @if ($service->image)
-                <img src="{{ asset('storage/' . $service->image) }}" alt="{{ $service->name }}"
-                    class="h-16 w-16 object-cover">
-                @endif
-            </td>
-            <td class="border px-4 py-2">
-                <a href="{{ route('admin.services.edit', $service) }}" class="text-blue-500 hover:underline">Edit</a>
-                <form action="{{ route('admin.services.destroy', $service) }}" method="POST" class="inline-block ml-2">
-                    @csrf
-                    @method('DELETE')
-                    <button type="submit" class="text-red-500 hover:underline"
-                        onclick="return confirm('Are you sure?')">Delete</button>
-                </form>
-            </td>
-        </tr>
-        @endforeach
-    </tbody>
-</table>
-@endsection
-=======
     <table class="w-full bg-white shadow-md rounded-lg">
         <thead>
             <tr class="bg-gray-200">
@@ -76,15 +36,10 @@
                     </td>
                     <td class="border px-4 py-2">
                         <a href="{{ route('admin.services.edit', $service) }}" class="text-blue-500 hover:underline">Edit</a>
-                        <form action="{{ route('admin.services.destroy', $service) }}" method="POST" class="inline-block ml-2">
-                            @csrf
-                            @method('DELETE')
-                            <button type="submit" class="text-red-500 hover:underline" onclick="return confirm('Are you sure?')">Delete</button>
-                        </form>
+                        <x-admin.delete-button :route="route('admin.services.destroy', $service)" />
                     </td>
                 </tr>
             @endforeach
         </tbody>
     </table>
 @endsection
->>>>>>> 0663a064afa90305657742c6925db2c1b059ad95

--- a/resources/views/admin/social_media_links/create.blade.php
+++ b/resources/views/admin/social_media_links/create.blade.php
@@ -3,39 +3,18 @@
 @section('title', 'Create Social Media Links')
 @section('header-title', 'Create Social Media Links')
 
-
-
-
-
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Create Social Media Link</h1>
     </div>
 
-    @if ($errors->any())
-        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <ul>
-                @foreach ($errors->all() as $error)
-                    <li>{{ $error }}</li>
-                @endforeach
-            </ul>
-        </div>
-    @endif
+    <x-admin.validation-errors />
 
     <form action="{{ route('admin.social-media-links.store') }}" method="POST" enctype="multipart/form-data">
         @csrf
-        <div class="mb-4">
-            <label for="name" class="block text-gray-700">Name</label>
-            <input type="text" name="name" id="name" class="w-full border-gray-300 rounded-md shadow-sm" value="{{ old('name') }}" required>
-        </div>
-        <div class="mb-4">
-            <label for="url" class="block text-gray-700">URL</label>
-            <input type="url" name="url" id="url" class="w-full border-gray-300 rounded-md shadow-sm" value="{{ old('url') }}" required>
-        </div>
-        <div class="mb-4">
-            <label for="icon" class="block text-gray-700">Icon</label>
-            <input type="file" name="icon" id="icon" class="w-full border-gray-300 rounded-md shadow-sm" required>
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create</button>
+        <x-admin.text-input name="name" label="Name" required />
+        <x-admin.text-input name="url" label="URL" required />
+        <x-admin.file-input name="icon" label="Icon" />
+        <x-admin.submit-button label="Create" />
     </form>
 @endsection

--- a/resources/views/admin/social_media_links/edit.blade.php
+++ b/resources/views/admin/social_media_links/edit.blade.php
@@ -3,45 +3,19 @@
 @section('title', 'Edit Social Media Links')
 @section('header-title', 'Edit Social Media Links')
 
-
-
-
-
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Edit Social Media Link</h1>
     </div>
 
-    @if ($errors->any())
-        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <ul>
-                @foreach ($errors->all() as $error)
-                    <li>{{ $error }}</li>
-                @endforeach
-            </ul>
-        </div>
-    @endif
+    <x-admin.validation-errors />
 
     <form action="{{ route('admin.social-media-links.update', $socialMediaLink) }}" method="POST" enctype="multipart/form-data">
         @csrf
         @method('PUT')
-        <div class="mb-4">
-            <label for="name" class="block text-gray-700">Name</label>
-            <input type="text" name="name" id="name" class="w-full border-gray-300 rounded-md shadow-sm" value="{{ old('name', $socialMediaLink->name) }}" required>
-        </div>
-        <div class="mb-4">
-            <label for="url" class="block text-gray-700">URL</label>
-            <input type="url" name="url" id="url" class="w-full border-gray-300 rounded-md shadow-sm" value="{{ old('url', $socialMediaLink->url) }}" required>
-        </div>
-        <div class="mb-4">
-            <label for="icon" class="block text-gray-700">Icon</label>
-            <input type="file" name="icon" id="icon" class="w-full border-gray-300 rounded-md shadow-sm">
-            @if ($socialMediaLink->icon)
-                <div class="mt-2">
-                    <img src="{{ asset('storage/' . $socialMediaLink->icon) }}" alt="{{ $socialMediaLink->name }}" class="h-16">
-                </div>
-            @endif
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Update</button>
+        <x-admin.text-input name="name" label="Name" :value="$socialMediaLink->name" required />
+        <x-admin.text-input name="url" label="URL" :value="$socialMediaLink->url" required />
+        <x-admin.file-input name="icon" label="Icon" :value="$socialMediaLink->icon" />
+        <x-admin.submit-button label="Update" />
     </form>
 @endsection

--- a/resources/views/admin/social_media_links/index.blade.php
+++ b/resources/views/admin/social_media_links/index.blade.php
@@ -3,21 +3,11 @@
 @section('title', 'Index Social Media Links')
 @section('header-title', 'Index Social Media Links')
 
-
-
-
-
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Social Media Links</h1>
         <a href="{{ route('admin.social-media-links.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
     </div>
-
-    @if (session('success'))
-        <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <span class="block sm:inline">{{ session('success') }}</span>
-        </div>
-    @endif
 
     <table class="w-full bg-white shadow-md rounded-lg">
         <thead>
@@ -34,15 +24,13 @@
                     <td class="border px-4 py-2">{{ $socialMediaLink->name }}</td>
                     <td class="border px-4 py-2">{{ $socialMediaLink->url }}</td>
                     <td class="border px-4 py-2">
-                        <img src="{{ asset('storage/' . $socialMediaLink->icon) }}" alt="{{ $socialMediaLink->name }}" class="h-16">
+                        @if ($socialMediaLink->icon)
+                            <img src="{{ asset('storage/' . $socialMediaLink->icon) }}" alt="{{ $socialMediaLink->name }}" class="h-16 w-16 object-cover">
+                        @endif
                     </td>
                     <td class="border px-4 py-2">
                         <a href="{{ route('admin.social-media-links.edit', $socialMediaLink) }}" class="text-blue-500 hover:underline">Edit</a>
-                        <form action="{{ route('admin.social-media-links.destroy', $socialMediaLink) }}" method="POST" class="inline-block ml-2">
-                            @csrf
-                            @method('DELETE')
-                            <button type="submit" class="text-red-500 hover:underline" onclick="return confirm('Are you sure?')">Delete</button>
-                        </form>
+                        <x-admin.delete-button :route="route('admin.social-media-links.destroy', $socialMediaLink)" />
                     </td>
                 </tr>
             @endforeach

--- a/resources/views/admin/software-categories/create.blade.php
+++ b/resources/views/admin/software-categories/create.blade.php
@@ -3,29 +3,13 @@
 @section('title', 'Create Software Categories')
 @section('header-title', 'Create Software Categories')
 
-
-
-
-
 @section('content')
     <h1 class="text-2xl font-bold mb-4">Create Software Category</h1>
 
     <form action="{{ route('admin.software-categories.store') }}" method="POST">
         @csrf
-        <div class="mb-4">
-            <label for="name" class="block text-gray-700">Name</label>
-            <input type="text" name="name" id="name" class="w-full px-3 py-2 border rounded-md" value="{{ old('name') }}" required>
-            @error('name')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="slug" class="block text-gray-700">Slug</label>
-            <input type="text" name="slug" id="slug" class="w-full px-3 py-2 border rounded-md" value="{{ old('slug') }}" required>
-            @error('slug')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create</button>
+        <x-admin.text-input name="name" label="Name" required />
+        <x-admin.text-input name="slug" label="Slug" required />
+        <x-admin.submit-button label="Create" />
     </form>
 @endsection

--- a/resources/views/admin/software-categories/edit.blade.php
+++ b/resources/views/admin/software-categories/edit.blade.php
@@ -3,30 +3,14 @@
 @section('title', 'Edit Software Categories')
 @section('header-title', 'Edit Software Categories')
 
-
-
-
-
 @section('content')
     <h1 class="text-2xl font-bold mb-4">Edit Software Category</h1>
 
     <form action="{{ route('admin.software-categories.update', $softwareCategory) }}" method="POST">
         @csrf
         @method('PUT')
-        <div class="mb-4">
-            <label for="name" class="block text-gray-700">Name</label>
-            <input type="text" name="name" id="name" class="w-full px-3 py-2 border rounded-md" value="{{ old('name', $softwareCategory->name) }}" required>
-            @error('name')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="slug" class="block text-gray-700">Slug</label>
-            <input type="text" name="slug" id="slug" class="w-full px-3 py-2 border rounded-md" value="{{ old('slug', $softwareCategory->slug) }}" required>
-            @error('slug')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Update</button>
+        <x-admin.text-input name="name" label="Name" :value="$softwareCategory->name" required />
+        <x-admin.text-input name="slug" label="Slug" :value="$softwareCategory->slug" required />
+        <x-admin.submit-button label="Update" />
     </form>
 @endsection

--- a/resources/views/admin/software-categories/index.blade.php
+++ b/resources/views/admin/software-categories/index.blade.php
@@ -3,21 +3,11 @@
 @section('title', 'Index Software Categories')
 @section('header-title', 'Index Software Categories')
 
-
-
-
-
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Software Categories</h1>
         <a href="{{ route('admin.software-categories.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
     </div>
-
-    @if (session('success'))
-        <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <span class="block sm:inline">{{ session('success') }}</span>
-        </div>
-    @endif
 
     <table class="w-full bg-white shadow-md rounded-lg">
         <thead>
@@ -34,11 +24,7 @@
                     <td class="border px-4 py-2">{{ $category->slug }}</td>
                     <td class="border px-4 py-2">
                         <a href="{{ route('admin.software-categories.edit', $category) }}" class="text-blue-500 hover:underline">Edit</a>
-                        <form action="{{ route('admin.software-categories.destroy', $category) }}" method="POST" class="inline-block ml-2">
-                            @csrf
-                            @method('DELETE')
-                            <button type="submit" class="text-red-500 hover:underline" onclick="return confirm('Are you sure?')">Delete</button>
-                        </form>
+                        <x-admin.delete-button :route="route('admin.software-categories.destroy', $category)" />
                     </td>
                 </tr>
             @endforeach

--- a/resources/views/admin/softwares/create.blade.php
+++ b/resources/views/admin/softwares/create.blade.php
@@ -3,47 +3,15 @@
 @section('title', 'Create Softwares')
 @section('header-title', 'Create Softwares')
 
-
-
-
-
 @section('content')
     <h1 class="text-2xl font-bold mb-4">Create Software</h1>
 
     <form action="{{ route('admin.softwares.store') }}" method="POST" enctype="multipart/form-data">
         @csrf
-        <div class="mb-4">
-            <label for="name" class="block text-gray-700">Name</label>
-            <input type="text" name="name" id="name" class="w-full px-3 py-2 border rounded-md" value="{{ old('name') }}" required>
-            @error('name')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="slug" class="block text-gray-700">Slug</label>
-            <input type="text" name="slug" id="slug" class="w-full px-3 py-2 border rounded-md" value="{{ old('slug') }}" required>
-            @error('slug')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="software_category_id" class="block text-gray-700">Category</label>
-            <select name="software_category_id" id="software_category_id" class="w-full px-3 py-2 border rounded-md" required>
-                @foreach ($categories as $category)
-                    <option value="{{ $category->id }}">{{ $category->name }}</option>
-                @endforeach
-            </select>
-            @error('software_category_id')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="image" class="block text-gray-700">Image</label>
-            <input type="file" name="image" id="image" class="w-full px-3 py-2 border rounded-md">
-            @error('image')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create</button>
+        <x-admin.text-input name="name" label="Name" required />
+        <x-admin.text-input name="slug" label="Slug" required />
+        <x-admin.select name="software_category_id" label="Category" :options="$categories->pluck('name', 'id')" required />
+        <x-admin.file-input name="image" label="Image" />
+        <x-admin.submit-button label="Create" />
     </form>
 @endsection

--- a/resources/views/admin/softwares/edit.blade.php
+++ b/resources/views/admin/softwares/edit.blade.php
@@ -3,51 +3,16 @@
 @section('title', 'Edit Softwares')
 @section('header-title', 'Edit Softwares')
 
-
-
-
-
 @section('content')
     <h1 class="text-2xl font-bold mb-4">Edit Software</h1>
 
     <form action="{{ route('admin.softwares.update', $software) }}" method="POST" enctype="multipart/form-data">
         @csrf
         @method('PUT')
-        <div class="mb-4">
-            <label for="name" class="block text-gray-700">Name</label>
-            <input type="text" name="name" id="name" class="w-full px-3 py-2 border rounded-md" value="{{ old('name', $software->name) }}" required>
-            @error('name')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="slug" class="block text-gray-700">Slug</label>
-            <input type="text" name="slug" id="slug" class="w-full px-3 py-2 border rounded-md" value="{{ old('slug', $software->slug) }}" required>
-            @error('slug')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="software_category_id" class="block text-gray-700">Category</label>
-            <select name="software_category_id" id="software_category_id" class="w-full px-3 py-2 border rounded-md" required>
-                @foreach ($categories as $category)
-                    <option value="{{ $category->id }}" @selected($software->software_category_id == $category->id)>{{ $category->name }}</option>
-                @endforeach
-            </select>
-            @error('software_category_id')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="image" class="block text-gray-700">Image</label>
-            <input type="file" name="image" id="image" class="w-full px-3 py-2 border rounded-md">
-            @if ($software->image)
-                <img src="{{ asset('storage/' . $software->image) }}" alt="{{ $software->name }}" class="h-16 w-16 object-cover mt-2">
-            @endif
-            @error('image')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Update</button>
+        <x-admin.text-input name="name" label="Name" :value="$software->name" required />
+        <x-admin.text-input name="slug" label="Slug" :value="$software->slug" required />
+        <x-admin.select name="software_category_id" label="Category" :options="$categories->pluck('name', 'id')" :value="$software->software_category_id" required />
+        <x-admin.file-input name="image" label="Image" :value="$software->image" />
+        <x-admin.submit-button label="Update" />
     </form>
 @endsection

--- a/resources/views/admin/softwares/index.blade.php
+++ b/resources/views/admin/softwares/index.blade.php
@@ -3,21 +3,11 @@
 @section('title', 'Index Softwares')
 @section('header-title', 'Index Softwares')
 
-
-
-
-
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Softwares</h1>
         <a href="{{ route('admin.softwares.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
     </div>
-
-    @if (session('success'))
-        <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <span class="block sm:inline">{{ session('success') }}</span>
-        </div>
-    @endif
 
     <table class="w-full bg-white shadow-md rounded-lg">
         <thead>
@@ -40,11 +30,7 @@
                     </td>
                     <td class="border px-4 py-2">
                         <a href="{{ route('admin.softwares.edit', $software) }}" class="text-blue-500 hover:underline">Edit</a>
-                        <form action="{{ route('admin.softwares.destroy', $software) }}" method="POST" class="inline-block ml-2">
-                            @csrf
-                            @method('DELETE')
-                            <button type="submit" class="text-red-500 hover:underline" onclick="return confirm('Are you sure?')">Delete</button>
-                        </form>
+                        <x-admin.delete-button :route="route('admin.softwares.destroy', $software)" />
                     </td>
                 </tr>
             @endforeach

--- a/resources/views/admin/tags/create.blade.php
+++ b/resources/views/admin/tags/create.blade.php
@@ -3,22 +3,12 @@
 @section('title', 'Create Tags')
 @section('header-title', 'Create Tags')
 
-
-
-
-
 @section('content')
     <h1 class="text-2xl font-bold mb-4">Create Tag</h1>
 
     <form action="{{ route('admin.tags.store') }}" method="POST">
         @csrf
-        <div class="mb-4">
-            <label for="name" class="block text-gray-700">Name</label>
-            <input type="text" name="name" id="name" class="w-full px-3 py-2 border rounded-md" value="{{ old('name') }}" required>
-            @error('name')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create</button>
+        <x-admin.text-input name="name" label="Name" required />
+        <x-admin.submit-button label="Create" />
     </form>
 @endsection

--- a/resources/views/admin/tags/edit.blade.php
+++ b/resources/views/admin/tags/edit.blade.php
@@ -3,23 +3,13 @@
 @section('title', 'Edit Tags')
 @section('header-title', 'Edit Tags')
 
-
-
-
-
 @section('content')
     <h1 class="text-2xl font-bold mb-4">Edit Tag</h1>
 
     <form action="{{ route('admin.tags.update', $tag) }}" method="POST">
         @csrf
         @method('PUT')
-        <div class="mb-4">
-            <label for="name" class="block text-gray-700">Name</label>
-            <input type="text" name="name" id="name" class="w-full px-3 py-2 border rounded-md" value="{{ old('name', $tag->name) }}" required>
-            @error('name')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Update</button>
+        <x-admin.text-input name="name" label="Name" :value="$tag->name" required />
+        <x-admin.submit-button label="Update" />
     </form>
 @endsection

--- a/resources/views/admin/tags/index.blade.php
+++ b/resources/views/admin/tags/index.blade.php
@@ -3,21 +3,11 @@
 @section('title', 'Index Tags')
 @section('header-title', 'Index Tags')
 
-
-
-
-
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Tags</h1>
         <a href="{{ route('admin.tags.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
     </div>
-
-    @if (session('success'))
-        <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <span class="block sm:inline">{{ session('success') }}</span>
-        </div>
-    @endif
 
     <table class="w-full bg-white shadow-md rounded-lg">
         <thead>
@@ -32,11 +22,7 @@
                     <td class="border px-4 py-2">{{ $tag->name }}</td>
                     <td class="border px-4 py-2">
                         <a href="{{ route('admin.tags.edit', $tag) }}" class="text-blue-500 hover:underline">Edit</a>
-                        <form action="{{ route('admin.tags.destroy', $tag) }}" method="POST" class="inline-block ml-2">
-                            @csrf
-                            @method('DELETE')
-                            <button type="submit" class="text-red-500 hover:underline" onclick="return confirm('Are you sure?')">Delete</button>
-                        </form>
+                        <x-admin.delete-button :route="route('admin.tags.destroy', $tag)" />
                     </td>
                 </tr>
             @endforeach

--- a/resources/views/admin/technologies/create.blade.php
+++ b/resources/views/admin/technologies/create.blade.php
@@ -3,10 +3,6 @@
 @section('title', 'Create Technologies')
 @section('header-title', 'Create Technologies')
 
-
-
-
-
 @section('content')
     <div class="container-fluid">
         <div class="row">
@@ -19,29 +15,10 @@
                     <div class="card-body">
                         <form action="{{ route('admin.technologies.store') }}" method="POST" enctype="multipart/form-data">
                             @csrf
-                            <div class="form-group">
-                                <label for="name">Name</label>
-                                <input type="text" name="name" id="name" class="form-control"
-                                    value="{{ old('name') }}">
-                                @error('name')
-                                    <span class="text-danger">{{ $message }}</span>
-                                @enderror
-                            </div>
-                            <div class="form-group">
-                                <label for="description">Description</label>
-                                <textarea name="description" id="description" class="form-control">{{ old('description') }}</textarea>
-                                @error('description')
-                                    <span class="text-danger">{{ $message }}</span>
-                                @enderror
-                            </div>
-                            <div class="form-group">
-                                <label for="image">Image</label>
-                                <input type="file" name="image" id="image" class="form-control">
-                                @error('image')
-                                    <span class="text-danger">{{ $message }}</span>
-                                @enderror
-                            </div>
-                            <button type="submit" class="btn btn-primary">Create</button>
+                            <x-admin.bootstrap.text-input name="name" label="Name" required />
+                            <x-admin.bootstrap.textarea name="description" label="Description" />
+                            <x-admin.bootstrap.file-input name="image" label="Image" />
+                            <x-admin.bootstrap.submit-button label="Create" />
                         </form>
                     </div>
                     <!-- /.card-body -->

--- a/resources/views/admin/technologies/edit.blade.php
+++ b/resources/views/admin/technologies/edit.blade.php
@@ -3,10 +3,6 @@
 @section('title', 'Edit Technologies')
 @section('header-title', 'Edit Technologies')
 
-
-
-
-
 @section('content')
     <div class="container-fluid">
         <div class="row">
@@ -21,33 +17,10 @@
                             enctype="multipart/form-data">
                             @csrf
                             @method('PUT')
-                            <div class="form-group">
-                                <label for="name">Name</label>
-                                <input type="text" name="name" id="name" class="form-control"
-                                    value="{{ old('name', $technology->name) }}">
-                                @error('name')
-                                    <span class="text-danger">{{ $message }}</span>
-                                @enderror
-                            </div>
-                            <div class="form-group">
-                                <label for="description">Description</label>
-                                <textarea name="description" id="description" class="form-control">{{ old('description', $technology->description) }}</textarea>
-                                @error('description')
-                                    <span class="text-danger">{{ $message }}</span>
-                                @enderror
-                            </div>
-                            <div class="form-group">
-                                <label for="image">Image</label>
-                                <input type="file" name="image" id="image" class="form-control">
-                                @error('image')
-                                    <span class="text-danger">{{ $message }}</span>
-                                @enderror
-                                @if ($technology->image)
-                                    <img src="{{ asset('storage/technologies/' . $technology->image) }}"
-                                        alt="{{ $technology->name }}" width="100" class="mt-2">
-                                @endif
-                            </div>
-                            <button type="submit" class="btn btn-primary">Update</button>
+                            <x-admin.bootstrap.text-input name="name" label="Name" :value="$technology->name" required />
+                            <x-admin.bootstrap.textarea name="description" label="Description" :value="$technology->description" />
+                            <x-admin.bootstrap.file-input name="image" label="Image" :value="$technology->image" />
+                            <x-admin.bootstrap.submit-button label="Update" />
                         </form>
                     </div>
                     <!-- /.card-body -->

--- a/resources/views/admin/technologies/index.blade.php
+++ b/resources/views/admin/technologies/index.blade.php
@@ -3,58 +3,44 @@
 @section('title', 'Index Technologies')
 @section('header-title', 'Index Technologies')
 
-
-
-
-
 @section('content')
     <div class="container-fluid">
         <div class="row">
             <div class="col-12">
                 <div class="card">
-                    <div class="card-header d-flex justify-content-between">
+                    <div class="card-header">
                         <h3 class="card-title">Technologies</h3>
-                        <a href="{{ route('admin.technologies.create') }}" class="btn btn-primary">Create Technology</a>
+                        <a href="{{ route('admin.technologies.create') }}" class="btn btn-primary float-right">Create New</a>
                     </div>
-                    <!-- /.card-header -->
                     <div class="card-body">
-                        <table id="example1" class="table table-bordered table-striped">
+                        <table class="table table-bordered">
                             <thead>
                                 <tr>
-                                    <th>#</th>
-                                    <th>Image</th>
                                     <th>Name</th>
                                     <th>Description</th>
-                                    <th>Action</th>
+                                    <th>Image</th>
+                                    <th>Actions</th>
                                 </tr>
                             </thead>
                             <tbody>
                                 @foreach ($technologies as $technology)
                                     <tr>
-                                        <td>{{ $loop->iteration }}</td>
-                                        <td>
-                                            <img src="{{ asset('storage/technologies/' . $technology->image) }}"
-                                                alt="{{ $technology->name }}" width="100">
-                                        </td>
                                         <td>{{ $technology->name }}</td>
                                         <td>{{ $technology->description }}</td>
                                         <td>
-                                            <a href="{{ route('admin.technologies.edit', $technology->id) }}"
-                                                class="btn btn-primary">Edit</a>
-                                            <form action="{{ route('admin.technologies.destroy', $technology->id) }}"
-                                                method="POST" class="d-inline">
-                                                @csrf
-                                                @method('DELETE')
-                                                <button type="submit" class="btn btn-danger"
-                                                    onclick="return confirm('Are you sure?')">Delete</button>
-                                            </form>
+                                            @if ($technology->image)
+                                                <img src="{{ asset('storage/technologies/' . $technology->image) }}" alt="{{ $technology->name }}" width="100">
+                                            @endif
+                                        </td>
+                                        <td>
+                                            <a href="{{ route('admin.technologies.edit', $technology) }}" class="btn btn-info btn-sm">Edit</a>
+                                            <x-admin.bootstrap.delete-button :route="route('admin.technologies.destroy', $technology)" />
                                         </td>
                                     </tr>
                                 @endforeach
                             </tbody>
                         </table>
                     </div>
-                    <!-- /.card-body -->
                 </div>
             </div>
         </div>

--- a/resources/views/admin/trusted_companies/create.blade.php
+++ b/resources/views/admin/trusted_companies/create.blade.php
@@ -3,35 +3,17 @@
 @section('title', 'Create Trusted Companies')
 @section('header-title', 'Create Trusted Companies')
 
-
-
-
-
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Create Trusted Company</h1>
     </div>
 
-    @if ($errors->any())
-        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <ul>
-                @foreach ($errors->all() as $error)
-                    <li>{{ $error }}</li>
-                @endforeach
-            </ul>
-        </div>
-    @endif
+    <x-admin.validation-errors />
 
     <form action="{{ route('admin.trusted-companies.store') }}" method="POST" enctype="multipart/form-data">
         @csrf
-        <div class="mb-4">
-            <label for="name" class="block text-gray-700">Name</label>
-            <input type="text" name="name" id="name" class="w-full border-gray-300 rounded-md shadow-sm" value="{{ old('name') }}" required>
-        </div>
-        <div class="mb-4">
-            <label for="logo" class="block text-gray-700">Logo</label>
-            <input type="file" name="logo" id="logo" class="w-full border-gray-300 rounded-md shadow-sm" required>
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create</button>
+        <x-admin.text-input name="name" label="Name" required />
+        <x-admin.file-input name="logo" label="Logo" />
+        <x-admin.submit-button label="Create" />
     </form>
 @endsection

--- a/resources/views/admin/trusted_companies/edit.blade.php
+++ b/resources/views/admin/trusted_companies/edit.blade.php
@@ -3,39 +3,18 @@
 @section('title', 'Edit Trusted Companies')
 @section('header-title', 'Edit Trusted Companies')
 
-
-
-
-
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Edit Trusted Company</h1>
     </div>
 
-    @if ($errors->any())
-        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <ul>
-                @foreach ($errors->all() as $error)
-                    <li>{{ $error }}</li>
-                @endforeach
-            </ul>
-        </div>
-    @endif
+    <x-admin.validation-errors />
 
     <form action="{{ route('admin.trusted-companies.update', $trustedCompany) }}" method="POST" enctype="multipart/form-data">
         @csrf
         @method('PUT')
-        <div class="mb-4">
-            <label for="name" class="block text-gray-700">Name</label>
-            <input type="text" name="name" id="name" class="w-full border-gray-300 rounded-md shadow-sm" value="{{ old('name', $trustedCompany->name) }}" required>
-        </div>
-        <div class="mb-4">
-            <label for="logo" class="block text-gray-700">Logo</label>
-            <input type="file" name="logo" id="logo" class="w-full border-gray-300 rounded-md shadow-sm">
-            @if ($trustedCompany->logo)
-                <img src="{{ asset('storage/' . $trustedCompany->logo) }}" alt="{{ $trustedCompany->name }}" class="h-16 w-16 object-cover mt-2">
-            @endif
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Update</button>
+        <x-admin.text-input name="name" label="Name" :value="$trustedCompany->name" required />
+        <x-admin.file-input name="logo" label="Logo" :value="$trustedCompany->logo" />
+        <x-admin.submit-button label="Update" />
     </form>
 @endsection

--- a/resources/views/admin/trusted_companies/index.blade.php
+++ b/resources/views/admin/trusted_companies/index.blade.php
@@ -3,21 +3,11 @@
 @section('title', 'Index Trusted Companies')
 @section('header-title', 'Index Trusted Companies')
 
-
-
-
-
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Trusted Companies</h1>
         <a href="{{ route('admin.trusted-companies.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
     </div>
-
-    @if (session('success'))
-        <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <span class="block sm:inline">{{ session('success') }}</span>
-        </div>
-    @endif
 
     <table class="w-full bg-white shadow-md rounded-lg">
         <thead>
@@ -38,11 +28,7 @@
                     </td>
                     <td class="border px-4 py-2">
                         <a href="{{ route('admin.trusted-companies.edit', $trustedCompany) }}" class="text-blue-500 hover:underline">Edit</a>
-                        <form action="{{ route('admin.trusted-companies.destroy', $trustedCompany) }}" method="POST" class="inline-block ml-2">
-                            @csrf
-                            @method('DELETE')
-                            <button type="submit" class="text-red-500 hover:underline" onclick="return confirm('Are you sure?')">Delete</button>
-                        </form>
+                        <x-admin.delete-button :route="route('admin.trusted-companies.destroy', $trustedCompany)" />
                     </td>
                 </tr>
             @endforeach

--- a/resources/views/admin/vacancies/create.blade.php
+++ b/resources/views/admin/vacancies/create.blade.php
@@ -3,73 +3,26 @@
 @section('title', 'Create Vacancies')
 @section('header-title', 'Create Vacancies')
 
-
-
-
-
 @section('content')
     <h1 class="text-2xl font-bold mb-4">Create Vacancy</h1>
 
     <form action="{{ route('admin.vacancies.store') }}" method="POST">
         @csrf
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div class="mb-4">
-                <label for="title" class="block text-gray-700">Title</label>
-                <input type="text" name="title" id="title" class="w-full px-3 py-2 border rounded-md" value="{{ old('title') }}" required>
-            </div>
-            <div class="mb-4">
-                <label for="slug" class="block text-gray-700">Slug</label>
-                <input type="text" name="slug" id="slug" class="w-full px-3 py-2 border rounded-md" value="{{ old('slug') }}" required>
-            </div>
-            <div class="mb-4">
-                <label for="vacancy_category_id" class="block text-gray-700">Category</label>
-                <select name="vacancy_category_id" id="vacancy_category_id" class="w-full px-3 py-2 border rounded-md" required>
-                    @foreach ($categories as $category)
-                        <option value="{{ $category->id }}">{{ $category->name }}</option>
-                    @endforeach
-                </select>
-            </div>
-            <div class="mb-4">
-                <label for="type" class="block text-gray-700">Type</label>
-                <input type="text" name="type" id="type" class="w-full px-3 py-2 border rounded-md" value="{{ old('type') }}">
-            </div>
-            <div class="mb-4">
-                <label for="location" class="block text-gray-700">Location</label>
-                <input type="text" name="location" id="location" class="w-full px-3 py-2 border rounded-md" value="{{ old('location') }}">
-            </div>
-            <div class="mb-4">
-                <label for="end_date" class="block text-gray-700">End Date</label>
-                <input type="date" name="end_date" id="end_date" class="w-full px-3 py-2 border rounded-md" value="{{ old('end_date') }}">
-            </div>
-            <div class="mb-4">
-                <label for="salary" class="block text-gray-700">Salary</label>
-                <input type="text" name="salary" id="salary" class="w-full px-3 py-2 border rounded-md" value="{{ old('salary') }}">
-            </div>
-            <div class="mb-4">
-                <label for="weekly_holidays" class="block text-gray-700">Weekly Holidays</label>
-                <input type="text" name="weekly_holidays" id="weekly_holidays" class="w-full px-3 py-2 border rounded-md" value="{{ old('weekly_holidays') }}">
-            </div>
+            <x-admin.text-input name="title" label="Title" required />
+            <x-admin.text-input name="slug" label="Slug" required />
+            <x-admin.select name="vacancy_category_id" label="Category" :options="$categories->pluck('name', 'id')" required />
+            <x-admin.text-input name="type" label="Type" />
+            <x-admin.text-input name="location" label="Location" />
+            <x-admin.text-input name="end_date" label="End Date" />
+            <x-admin.text-input name="salary" label="Salary" />
+            <x-admin.text-input name="weekly_holidays" label="Weekly Holidays" />
         </div>
-        <div class="mb-4">
-            <label for="benefits" class="block text-gray-700">Benefits</label>
-            <textarea name="benefits" id="benefits" class="w-full px-3 py-2 border rounded-md">{{ old('benefits') }}</textarea>
-        </div>
-        <div class="mb-4">
-            <label for="responsibilities" class="block text-gray-700">Responsibilities</label>
-            <textarea name="responsibilities" id="responsibilities" class="w-full px-3 py-2 border rounded-md">{{ old('responsibilities') }}</textarea>
-        </div>
-        <div class="mb-4">
-            <label for="requirements" class="block text-gray-700">Requirements</label>
-            <textarea name="requirements" id="requirements" class="w-full px-3 py-2 border rounded-md">{{ old('requirements') }}</textarea>
-        </div>
-        <div class="mb-4">
-            <label for="skills_required" class="block text-gray-700">Skills Required</label>
-            <textarea name="skills_required" id="skills_required" class="w-full px-3 py-2 border rounded-md">{{ old('skills_required') }}</textarea>
-        </div>
-        <div class="mb-4">
-            <label for="others" class="block text-gray-700">Others</label>
-            <textarea name="others" id="others" class="w-full px-3 py-2 border rounded-md">{{ old('others') }}</textarea>
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create</button>
+        <x-admin.textarea name="benefits" label="Benefits" />
+        <x-admin.textarea name="responsibilities" label="Responsibilities" />
+        <x-admin.textarea name="requirements" label="Requirements" />
+        <x-admin.textarea name="skills_required" label="Skills Required" />
+        <x-admin.textarea name="others" label="Others" />
+        <x-admin.submit-button label="Create" />
     </form>
 @endsection

--- a/resources/views/admin/vacancies/edit.blade.php
+++ b/resources/views/admin/vacancies/edit.blade.php
@@ -3,10 +3,6 @@
 @section('title', 'Edit Vacancies')
 @section('header-title', 'Edit Vacancies')
 
-
-
-
-
 @section('content')
     <h1 class="text-2xl font-bold mb-4">Edit Vacancy</h1>
 
@@ -14,63 +10,20 @@
         @csrf
         @method('PATCH')
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div class="mb-4">
-                <label for="title" class="block text-gray-700">Title</label>
-                <input type="text" name="title" id="title" class="w-full px-3 py-2 border rounded-md" value="{{ old('title', $vacancy->title) }}" required>
-            </div>
-            <div class="mb-4">
-                <label for="slug" class="block text-gray-700">Slug</label>
-                <input type="text" name="slug" id="slug" class="w-full px-3 py-2 border rounded-md" value="{{ old('slug', $vacancy->slug) }}" required>
-            </div>
-            <div class="mb-4">
-                <label for="vacancy_category_id" class="block text-gray-700">Category</label>
-                <select name="vacancy_category_id" id="vacancy_category_id" class="w-full px-3 py-2 border rounded-md" required>
-                    @foreach ($categories as $category)
-                        <option value="{{ $category->id }}" @selected($vacancy->vacancy_category_id == $category->id)>{{ $category->name }}</option>
-                    @endforeach
-                </select>
-            </div>
-            <div class="mb-4">
-                <label for="type" class="block text-gray-700">Type</label>
-                <input type="text" name="type" id="type" class="w-full px-3 py-2 border rounded-md" value="{{ old('type', $vacancy->type) }}">
-            </div>
-            <div class="mb-4">
-                <label for="location" class="block text-gray-700">Location</label>
-                <input type="text" name="location" id="location" class="w-full px-3 py-2 border rounded-md" value="{{ old('location', $vacancy->location) }}">
-            </div>
-            <div class="mb-4">
-                <label for="end_date" class="block text-gray-700">End Date</label>
-                <input type="date" name="end_date" id="end_date" class="w-full px-3 py-2 border rounded-md" value="{{ old('end_date', $vacancy->end_date) }}">
-            </div>
-            <div class="mb-4">
-                <label for="salary" class="block text-gray-700">Salary</label>
-                <input type="text" name="salary" id="salary" class="w-full px-3 py-2 border rounded-md" value="{{ old('salary', $vacancy->salary) }}">
-            </div>
-            <div class="mb-4">
-                <label for="weekly_holidays" class="block text-gray-700">Weekly Holidays</label>
-                <input type="text" name="weekly_holidays" id="weekly_holidays" class="w-full px-3 py-2 border rounded-md" value="{{ old('weekly_holidays', $vacancy->weekly_holidays) }}">
-            </div>
+            <x-admin.text-input name="title" label="Title" :value="$vacancy->title" required />
+            <x-admin.text-input name="slug" label="Slug" :value="$vacancy->slug" required />
+            <x-admin.select name="vacancy_category_id" label="Category" :options="$categories->pluck('name', 'id')" :value="$vacancy->vacancy_category_id" required />
+            <x-admin.text-input name="type" label="Type" :value="$vacancy->type" />
+            <x-admin.text-input name="location" label="Location" :value="$vacancy->location" />
+            <x-admin.text-input name="end_date" label="End Date" :value="$vacancy->end_date" />
+            <x-admin.text-input name="salary" label="Salary" :value="$vacancy->salary" />
+            <x-admin.text-input name="weekly_holidays" label="Weekly Holidays" :value="$vacancy->weekly_holidays" />
         </div>
-        <div class="mb-4">
-            <label for="benefits" class="block text-gray-700">Benefits</label>
-            <textarea name="benefits" id="benefits" class="w-full px-3 py-2 border rounded-md">{{ old('benefits', $vacancy->benefits) }}</textarea>
-        </div>
-        <div class="mb-4">
-            <label for="responsibilities" class="block text-gray-700">Responsibilities</label>
-            <textarea name="responsibilities" id="responsibilities" class="w-full px-3 py-2 border rounded-md">{{ old('responsibilities', $vacancy->responsibilities) }}</textarea>
-        </div>
-        <div class="mb-4">
-            <label for="requirements" class="block text-gray-700">Requirements</label>
-            <textarea name="requirements" id="requirements" class="w-full px-3 py-2 border rounded-md">{{ old('requirements', $vacancy->requirements) }}</textarea>
-        </div>
-        <div class="mb-4">
-            <label for="skills_required" class="block text-gray-700">Skills Required</label>
-            <textarea name="skills_required" id="skills_required" class="w-full px-3 py-2 border rounded-md">{{ old('skills_required', $vacancy->skills_required) }}</textarea>
-        </div>
-        <div class="mb-4">
-            <label for="others" class="block text-gray-700">Others</label>
-            <textarea name="others" id="others" class="w-full px-3 py-2 border rounded-md">{{ old('others', $vacancy->others) }}</textarea>
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Update</button>
+        <x-admin.textarea name="benefits" label="Benefits" :value="$vacancy->benefits" />
+        <x-admin.textarea name="responsibilities" label="Responsibilities" :value="$vacancy->responsibilities" />
+        <x-admin.textarea name="requirements" label="Requirements" :value="$vacancy->requirements" />
+        <x-admin.textarea name="skills_required" label="Skills Required" :value="$vacancy->skills_required" />
+        <x-admin.textarea name="others" label="Others" :value="$vacancy->others" />
+        <x-admin.submit-button label="Update" />
     </form>
 @endsection

--- a/resources/views/admin/vacancies/index.blade.php
+++ b/resources/views/admin/vacancies/index.blade.php
@@ -3,21 +3,11 @@
 @section('title', 'Index Vacancies')
 @section('header-title', 'Index Vacancies')
 
-
-
-
-
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Vacancies</h1>
         <a href="{{ route('admin.vacancies.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
     </div>
-
-    @if (session('success'))
-        <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <span class="block sm:inline">{{ session('success') }}</span>
-        </div>
-    @endif
 
     <table class="w-full bg-white shadow-md rounded-lg">
         <thead>
@@ -38,11 +28,7 @@
                     <td class="border px-4 py-2">{{ $vacancy->end_date }}</td>
                     <td class="border px-4 py-2">
                         <a href="{{ route('admin.vacancies.edit', $vacancy) }}" class="text-blue-500 hover:underline">Edit</a>
-                        <form action="{{ route('admin.vacancies.destroy', $vacancy) }}" method="POST" class="inline-block ml-2">
-                            @csrf
-                            @method('DELETE')
-                            <button type="submit" class="text-red-500 hover:underline" onclick="return confirm('Are you sure?')">Delete</button>
-                        </form>
+                        <x-admin.delete-button :route="route('admin.vacancies.destroy', $vacancy)" />
                     </td>
                 </tr>
             @endforeach

--- a/resources/views/admin/vacancy-categories/create.blade.php
+++ b/resources/views/admin/vacancy-categories/create.blade.php
@@ -3,29 +3,13 @@
 @section('title', 'Create Vacancy Categories')
 @section('header-title', 'Create Vacancy Categories')
 
-
-
-
-
 @section('content')
     <h1 class="text-2xl font-bold mb-4">Create Vacancy Category</h1>
 
     <form action="{{ route('admin.vacancy-categories.store') }}" method="POST">
         @csrf
-        <div class="mb-4">
-            <label for="name" class="block text-gray-700">Name</label>
-            <input type="text" name="name" id="name" class="w-full px-3 py-2 border rounded-md" value="{{ old('name') }}" required>
-            @error('name')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="slug" class="block text-gray-700">Slug</label>
-            <input type="text" name="slug" id="slug" class="w-full px-3 py-2 border rounded-md" value="{{ old('slug') }}" required>
-            @error('slug')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create</button>
+        <x-admin.text-input name="name" label="Name" required />
+        <x-admin.text-input name="slug" label="Slug" required />
+        <x-admin.submit-button label="Create" />
     </form>
 @endsection

--- a/resources/views/admin/vacancy-categories/edit.blade.php
+++ b/resources/views/admin/vacancy-categories/edit.blade.php
@@ -3,30 +3,14 @@
 @section('title', 'Edit Vacancy Categories')
 @section('header-title', 'Edit Vacancy Categories')
 
-
-
-
-
 @section('content')
     <h1 class="text-2xl font-bold mb-4">Edit Vacancy Category</h1>
 
     <form action="{{ route('admin.vacancy-categories.update', $vacancyCategory) }}" method="POST">
         @csrf
         @method('PUT')
-        <div class="mb-4">
-            <label for="name" class="block text-gray-700">Name</label>
-            <input type="text" name="name" id="name" class="w-full px-3 py-2 border rounded-md" value="{{ old('name', $vacancyCategory->name) }}" required>
-            @error('name')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <div class="mb-4">
-            <label for="slug" class="block text-gray-700">Slug</label>
-            <input type="text" name="slug" id="slug" class="w-full px-3 py-2 border rounded-md" value="{{ old('slug', $vacancyCategory->slug) }}" required>
-            @error('slug')
-                <p class="text-red-500 text-xs mt-1">{{ $message }}</p>
-            @enderror
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Update</button>
+        <x-admin.text-input name="name" label="Name" :value="$vacancyCategory->name" required />
+        <x-admin.text-input name="slug" label="Slug" :value="$vacancyCategory->slug" required />
+        <x-admin.submit-button label="Update" />
     </form>
 @endsection

--- a/resources/views/admin/vacancy-categories/index.blade.php
+++ b/resources/views/admin/vacancy-categories/index.blade.php
@@ -3,21 +3,11 @@
 @section('title', 'Index Vacancy Categories')
 @section('header-title', 'Index Vacancy Categories')
 
-
-
-
-
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Vacancy Categories</h1>
         <a href="{{ route('admin.vacancy-categories.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
     </div>
-
-    @if (session('success'))
-        <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <span class="block sm:inline">{{ session('success') }}</span>
-        </div>
-    @endif
 
     <table class="w-full bg-white shadow-md rounded-lg">
         <thead>
@@ -34,11 +24,7 @@
                     <td class="border px-4 py-2">{{ $category->slug }}</td>
                     <td class="border px-4 py-2">
                         <a href="{{ route('admin.vacancy-categories.edit', $category) }}" class="text-blue-500 hover:underline">Edit</a>
-                        <form action="{{ route('admin.vacancy-categories.destroy', $category) }}" method="POST" class="inline-block ml-2">
-                            @csrf
-                            @method('DELETE')
-                            <button type="submit" class="text-red-500 hover:underline" onclick="return confirm('Are you sure?')">Delete</button>
-                        </form>
+                        <x-admin.delete-button :route="route('admin.vacancy-categories.destroy', $category)" />
                     </td>
                 </tr>
             @endforeach

--- a/resources/views/admin/values/create.blade.php
+++ b/resources/views/admin/values/create.blade.php
@@ -3,39 +3,18 @@
 @section('title', 'Create Values')
 @section('header-title', 'Create Values')
 
-
-
-
-
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Create Value</h1>
     </div>
 
-    @if ($errors->any())
-        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <ul>
-                @foreach ($errors->all() as $error)
-                    <li>{{ $error }}</li>
-                @endforeach
-            </ul>
-        </div>
-    @endif
+    <x-admin.validation-errors />
 
     <form action="{{ route('admin.values.store') }}" method="POST">
         @csrf
-        <div class="mb-4">
-            <label for="title" class="block text-gray-700">Title</label>
-            <input type="text" name="title" id="title" class="w-full border-gray-300 rounded-md shadow-sm" value="{{ old('title') }}" required>
-        </div>
-        <div class="mb-4">
-            <label for="description" class="block text-gray-700">Description</label>
-            <textarea name="description" id="description" class="w-full border-gray-300 rounded-md shadow-sm" required>{{ old('description') }}</textarea>
-        </div>
-        <div class="mb-4">
-            <label for="icon" class="block text-gray-700">Icon</label>
-            <input type="text" name="icon" id="icon" class="w-full border-gray-300 rounded-md shadow-sm" value="{{ old('icon') }}" required>
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create</button>
+        <x-admin.text-input name="title" label="Title" required />
+        <x-admin.textarea name="description" label="Description" />
+        <x-admin.text-input name="icon" label="Icon" required />
+        <x-admin.submit-button label="Create" />
     </form>
 @endsection

--- a/resources/views/admin/values/edit.blade.php
+++ b/resources/views/admin/values/edit.blade.php
@@ -3,40 +3,19 @@
 @section('title', 'Edit Values')
 @section('header-title', 'Edit Values')
 
-
-
-
-
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Edit Value</h1>
     </div>
 
-    @if ($errors->any())
-        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <ul>
-                @foreach ($errors->all() as $error)
-                    <li>{{ $error }}</li>
-                @endforeach
-            </ul>
-        </div>
-    @endif
+    <x-admin.validation-errors />
 
     <form action="{{ route('admin.values.update', $value) }}" method="POST">
         @csrf
         @method('PUT')
-        <div class="mb-4">
-            <label for="title" class="block text-gray-700">Title</label>
-            <input type="text" name="title" id="title" class="w-full border-gray-300 rounded-md shadow-sm" value="{{ old('title', $value->title) }}" required>
-        </div>
-        <div class="mb-4">
-            <label for="description" class="block text-gray-700">Description</label>
-            <textarea name="description" id="description" class="w-full border-gray-300 rounded-md shadow-sm" required>{{ old('description', $value->description) }}</textarea>
-        </div>
-        <div class="mb-4">
-            <label for="icon" class="block text-gray-700">Icon</label>
-            <input type="text" name="icon" id="icon" class="w-full border-gray-300 rounded-md shadow-sm" value="{{ old('icon', $value->icon) }}" required>
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Update</button>
+        <x-admin.text-input name="title" label="Title" :value="$value->title" required />
+        <x-admin.textarea name="description" label="Description" :value="$value->description" />
+        <x-admin.text-input name="icon" label="Icon" :value="$value->icon" required />
+        <x-admin.submit-button label="Update" />
     </form>
 @endsection

--- a/resources/views/admin/values/index.blade.php
+++ b/resources/views/admin/values/index.blade.php
@@ -3,21 +3,11 @@
 @section('title', 'Index Values')
 @section('header-title', 'Index Values')
 
-
-
-
-
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Values</h1>
         <a href="{{ route('admin.values.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
     </div>
-
-    @if (session('success'))
-        <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <span class="block sm:inline">{{ session('success') }}</span>
-        </div>
-    @endif
 
     <table class="w-full bg-white shadow-md rounded-lg">
         <thead>
@@ -36,11 +26,7 @@
                     <td class="border px-4 py-2">{{ $value->icon }}</td>
                     <td class="border px-4 py-2">
                         <a href="{{ route('admin.values.edit', $value) }}" class="text-blue-500 hover:underline">Edit</a>
-                        <form action="{{ route('admin.values.destroy', $value) }}" method="POST" class="inline-block ml-2">
-                            @csrf
-                            @method('DELETE')
-                            <button type="submit" class="text-red-500 hover:underline" onclick="return confirm('Are you sure?')">Delete</button>
-                        </form>
+                        <x-admin.delete-button :route="route('admin.values.destroy', $value)" />
                     </td>
                 </tr>
             @endforeach

--- a/resources/views/admin/working_processes/create.blade.php
+++ b/resources/views/admin/working_processes/create.blade.php
@@ -3,39 +3,18 @@
 @section('title', 'Create Working Processes')
 @section('header-title', 'Create Working Processes')
 
-
-
-
-
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Create Working Process</h1>
     </div>
 
-    @if ($errors->any())
-        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <ul>
-                @foreach ($errors->all() as $error)
-                    <li>{{ $error }}</li>
-                @endforeach
-            </ul>
-        </div>
-    @endif
+    <x-admin.validation-errors />
 
     <form action="{{ route('admin.working-processes.store') }}" method="POST">
         @csrf
-        <div class="mb-4">
-            <label for="title" class="block text-gray-700">Title</label>
-            <input type="text" name="title" id="title" class="w-full border-gray-300 rounded-md shadow-sm" value="{{ old('title') }}" required>
-        </div>
-        <div class="mb-4">
-            <label for="description" class="block text-gray-700">Description</label>
-            <textarea name="description" id="description" class="w-full border-gray-300 rounded-md shadow-sm" required>{{ old('description') }}</textarea>
-        </div>
-        <div class="mb-4">
-            <label for="icon" class="block text-gray-700">Icon</label>
-            <input type="text" name="icon" id="icon" class="w-full border-gray-300 rounded-md shadow-sm" value="{{ old('icon') }}" required>
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create</button>
+        <x-admin.text-input name="title" label="Title" required />
+        <x-admin.textarea name="description" label="Description" />
+        <x-admin.text-input name="icon" label="Icon" required />
+        <x-admin.submit-button label="Create" />
     </form>
 @endsection

--- a/resources/views/admin/working_processes/edit.blade.php
+++ b/resources/views/admin/working_processes/edit.blade.php
@@ -3,40 +3,19 @@
 @section('title', 'Edit Working Processes')
 @section('header-title', 'Edit Working Processes')
 
-
-
-
-
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Edit Working Process</h1>
     </div>
 
-    @if ($errors->any())
-        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <ul>
-                @foreach ($errors->all() as $error)
-                    <li>{{ $error }}</li>
-                @endforeach
-            </ul>
-        </div>
-    @endif
+    <x-admin.validation-errors />
 
     <form action="{{ route('admin.working-processes.update', $workingProcess) }}" method="POST">
         @csrf
         @method('PUT')
-        <div class="mb-4">
-            <label for="title" class="block text-gray-700">Title</label>
-            <input type="text" name="title" id="title" class="w-full border-gray-300 rounded-md shadow-sm" value="{{ old('title', $workingProcess->title) }}" required>
-        </div>
-        <div class="mb-4">
-            <label for="description" class="block text-gray-700">Description</label>
-            <textarea name="description" id="description" class="w-full border-gray-300 rounded-md shadow-sm" required>{{ old('description', $workingProcess->description) }}</textarea>
-        </div>
-        <div class="mb-4">
-            <label for="icon" class="block text-gray-700">Icon</label>
-            <input type="text" name="icon" id="icon" class="w-full border-gray-300 rounded-md shadow-sm" value="{{ old('icon', $workingProcess->icon) }}" required>
-        </div>
-        <button type="submit" class="px-4 py-2 bg-blue-500 text-white rounded-md">Update</button>
+        <x-admin.text-input name="title" label="Title" :value="$workingProcess->title" required />
+        <x-admin.textarea name="description" label="Description" :value="$workingProcess->description" />
+        <x-admin.text-input name="icon" label="Icon" :value="$workingProcess->icon" required />
+        <x-admin.submit-button label="Update" />
     </form>
 @endsection

--- a/resources/views/admin/working_processes/index.blade.php
+++ b/resources/views/admin/working_processes/index.blade.php
@@ -3,21 +3,11 @@
 @section('title', 'Index Working Processes')
 @section('header-title', 'Index Working Processes')
 
-
-
-
-
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Working Processes</h1>
         <a href="{{ route('admin.working-processes.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
     </div>
-
-    @if (session('success'))
-        <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4" role="alert">
-            <span class="block sm:inline">{{ session('success') }}</span>
-        </div>
-    @endif
 
     <table class="w-full bg-white shadow-md rounded-lg">
         <thead>
@@ -36,11 +26,7 @@
                     <td class="border px-4 py-2">{{ $workingProcess->icon }}</td>
                     <td class="border px-4 py-2">
                         <a href="{{ route('admin.working-processes.edit', $workingProcess) }}" class="text-blue-500 hover:underline">Edit</a>
-                        <form action="{{ route('admin.working-processes.destroy', $workingProcess) }}" method="POST" class="inline-block ml-2">
-                            @csrf
-                            @method('DELETE')
-                            <button type="submit" class="text-red-500 hover:underline" onclick="return confirm('Are you sure?')">Delete</button>
-                        </form>
+                        <x-admin.delete-button :route="route('admin.working-processes.destroy', $workingProcess)" />
                     </td>
                 </tr>
             @endforeach


### PR DESCRIPTION
This change refactors all index pages to use the new reusable delete-button component.

- A new `delete-button.blade.php` component was created for both Tailwind and Bootstrap to encapsulate the form required for deleting records.
- All index pages have been refactored to use the new `delete-button` component.
- This change improves the reusability and maintainability of the admin index pages.