### PR TITLE
Refactor: Create reusable create-button component

### DIFF
--- a/resources/views/admin/article-categories/index.blade.php
+++ b/resources/views/admin/article-categories/index.blade.php
@@ -6,7 +6,7 @@
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Article Categories</h1>
-        <a href="{{ route('admin.article-categories.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
+        <x-admin.create-button :route="route('admin.article-categories.create')" />
     </div>
 
     <table class="w-full bg-white shadow-md rounded-lg">

--- a/resources/views/admin/articles/index.blade.php
+++ b/resources/views/admin/articles/index.blade.php
@@ -6,7 +6,7 @@
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Articles</h1>
-        <a href="{{ route('admin.articles.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
+        <x-admin.create-button :route="route('admin.articles.create')" />
     </div>
 
     @if (session('success'))

--- a/resources/views/admin/clients/index.blade.php
+++ b/resources/views/admin/clients/index.blade.php
@@ -6,7 +6,7 @@
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Clients</h1>
-        <a href="{{ route('admin.clients.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
+        <x-admin.create-button :route="route('admin.clients.create')" />
     </div>
 
     <table class="w-full bg-white shadow-md rounded-lg">

--- a/resources/views/admin/faqs/index.blade.php
+++ b/resources/views/admin/faqs/index.blade.php
@@ -6,7 +6,7 @@
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">FAQs</h1>
-        <a href="{{ route('admin.faqs.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
+        <x-admin.create-button :route="route('admin.faqs.create')" />
     </div>
 
     <table class="w-full bg-white shadow-md rounded-lg">

--- a/resources/views/admin/features/index.blade.php
+++ b/resources/views/admin/features/index.blade.php
@@ -10,7 +10,7 @@
                 <div class="card">
                     <div class="card-header">
                         <h3 class="card-title">Features</h3>
-                        <a href="{{ route('admin.features.create') }}" class="btn btn-primary float-right">Create New</a>
+                        <x-admin.create-button :route="route('admin.features.create')" class="btn btn-primary float-right" />
                     </div>
                     <div class="card-body">
                         <table class="table table-bordered">

--- a/resources/views/admin/key_features/index.blade.php
+++ b/resources/views/admin/key_features/index.blade.php
@@ -10,7 +10,7 @@
                 <div class="card">
                     <div class="card-header">
                         <h3 class="card-title">Key Features</h3>
-                        <a href="{{ route('admin.key-features.create') }}" class="btn btn-primary float-right">Create New</a>
+                        <x-admin.create-button :route="route('admin.key-features.create')" class="btn btn-primary float-right" />
                     </div>
                     <div class="card-body">
                         <table class="table table-bordered">

--- a/resources/views/admin/price-plans/index.blade.php
+++ b/resources/views/admin/price-plans/index.blade.php
@@ -6,7 +6,7 @@
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Price Plans</h1>
-        <a href="{{ route('admin.price-plans.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
+        <x-admin.create-button :route="route('admin.price-plans.create')" />
     </div>
 
     <table class="w-full bg-white shadow-md rounded-lg">

--- a/resources/views/admin/project-categories/index.blade.php
+++ b/resources/views/admin/project-categories/index.blade.php
@@ -6,7 +6,7 @@
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Project Categories</h1>
-        <a href="{{ route('admin.project-categories.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
+        <x-admin.create-button :route="route('admin.project-categories.create')" />
     </div>
 
     <table class="w-full bg-white shadow-md rounded-lg">

--- a/resources/views/admin/projects/index.blade.php
+++ b/resources/views/admin/projects/index.blade.php
@@ -6,7 +6,7 @@
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Projects</h1>
-        <a href="{{ route('admin.projects.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
+        <x-admin.create-button :route="route('admin.projects.create')" />
     </div>
 
     <table class="w-full bg-white shadow-md rounded-lg">

--- a/resources/views/admin/service-categories/index.blade.php
+++ b/resources/views/admin/service-categories/index.blade.php
@@ -6,7 +6,7 @@
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Service Categories</h1>
-        <a href="{{ route('admin.service-categories.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
+        <x-admin.create-button :route="route('admin.service-categories.create')" />
     </div>
 
     <table class="w-full bg-white shadow-md rounded-lg">

--- a/resources/views/admin/service-types/index.blade.php
+++ b/resources/views/admin/service-types/index.blade.php
@@ -6,7 +6,7 @@
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Service Types</h1>
-        <a href="{{ route('admin.service-types.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
+        <x-admin.create-button :route="route('admin.service-types.create')" />
     </div>
 
     <table class="w-full bg-white shadow-md rounded-lg">

--- a/resources/views/admin/services/index.blade.php
+++ b/resources/views/admin/services/index.blade.php
@@ -6,7 +6,7 @@
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Services</h1>
-        <a href="{{ route('admin.services.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
+        <x-admin.create-button :route="route('admin.services.create')" />
     </div>
 
     @if (session('success'))

--- a/resources/views/admin/social_media_links/index.blade.php
+++ b/resources/views/admin/social_media_links/index.blade.php
@@ -6,7 +6,7 @@
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Social Media Links</h1>
-        <a href="{{ route('admin.social-media-links.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
+        <x-admin.create-button :route="route('admin.social-media-links.create')" />
     </div>
 
     <table class="w-full bg-white shadow-md rounded-lg">

--- a/resources/views/admin/software-categories/index.blade.php
+++ b/resources/views/admin/software-categories/index.blade.php
@@ -6,7 +6,7 @@
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Software Categories</h1>
-        <a href="{{ route('admin.software-categories.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
+        <x-admin.create-button :route="route('admin.software-categories.create')" />
     </div>
 
     <table class="w-full bg-white shadow-md rounded-lg">

--- a/resources/views/admin/softwares/index.blade.php
+++ b/resources/views/admin/softwares/index.blade.php
@@ -6,7 +6,7 @@
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Softwares</h1>
-        <a href="{{ route('admin.softwares.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
+        <x-admin.create-button :route="route('admin.softwares.create')" />
     </div>
 
     <table class="w-full bg-white shadow-md rounded-lg">

--- a/resources/views/admin/tags/index.blade.php
+++ b/resources/views/admin/tags/index.blade.php
@@ -6,7 +6,7 @@
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Tags</h1>
-        <a href="{{ route('admin.tags.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
+        <x-admin.create-button :route="route('admin.tags.create')" />
     </div>
 
     <table class="w-full bg-white shadow-md rounded-lg">

--- a/resources/views/admin/technologies/index.blade.php
+++ b/resources/views/admin/technologies/index.blade.php
@@ -10,7 +10,7 @@
                 <div class="card">
                     <div class="card-header">
                         <h3 class="card-title">Technologies</h3>
-                        <a href="{{ route('admin.technologies.create') }}" class="btn btn-primary float-right">Create New</a>
+                        <x-admin.create-button :route="route('admin.technologies.create')" class="btn btn-primary float-right" />
                     </div>
                     <div class="card-body">
                         <table class="table table-bordered">

--- a/resources/views/admin/trusted_companies/index.blade.php
+++ b/resources/views/admin/trusted_companies/index.blade.php
@@ -6,7 +6,7 @@
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Trusted Companies</h1>
-        <a href="{{ route('admin.trusted-companies.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
+        <x-admin.create-button :route="route('admin.trusted-companies.create')" />
     </div>
 
     <table class="w-full bg-white shadow-md rounded-lg">

--- a/resources/views/admin/vacancies/index.blade.php
+++ b/resources/views/admin/vacancies/index.blade.php
@@ -6,7 +6,7 @@
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Vacancies</h1>
-        <a href="{{ route('admin.vacancies.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
+        <x-admin.create-button :route="route('admin.vacancies.create')" />
     </div>
 
     <table class="w-full bg-white shadow-md rounded-lg">

--- a/resources/views/admin/vacancy-categories/index.blade.php
+++ b/resources/views/admin/vacancy-categories/index.blade.php
@@ -6,7 +6,7 @@
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Vacancy Categories</h1>
-        <a href="{{ route('admin.vacancy-categories.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
+        <x-admin.create-button :route="route('admin.vacancy-categories.create')" />
     </div>
 
     <table class="w-full bg-white shadow-md rounded-lg">

--- a/resources/views/admin/values/index.blade.php
+++ b/resources/views/admin/values/index.blade.php
@@ -6,7 +6,7 @@
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Values</h1>
-        <a href="{{ route('admin.values.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
+        <x-admin.create-button :route="route('admin.values.create')" />
     </div>
 
     <table class="w-full bg-white shadow-md rounded-lg">

--- a/resources/views/admin/working_processes/index.blade.php
+++ b/resources/views/admin/working_processes/index.blade.php
@@ -6,7 +6,7 @@
 @section('content')
     <div class="flex justify-between items-center mb-4">
         <h1 class="text-2xl font-bold">Working Processes</h1>
-        <a href="{{ route('admin.working-processes.create') }}" class="px-4 py-2 bg-blue-500 text-white rounded-md">Create New</a>
+        <x-admin.create-button :route="route('admin.working-processes.create')" />
     </div>
 
     <table class="w-full bg-white shadow-md rounded-lg">

--- a/resources/views/components/admin/create-button.blade.php
+++ b/resources/views/components/admin/create-button.blade.php
@@ -1,0 +1,3 @@
+@props(['route', 'class' => 'px-4 py-2 bg-blue-500 text-white rounded-md'])
+
+<a href="{{ $route }}" class="{{ $class }}">Create New</a>


### PR DESCRIPTION
Created a new Blade component `x-admin.create-button` to standardize the "Create New" button across the admin panel.

The component accepts a `route` prop for the link's destination and an optional `class` prop for custom styling, with a sensible default.

Replaced hardcoded buttons in 22 admin index views with the new reusable component, improving code maintainability and consistency.