### PR TITLE
feat: Make articles dynamic

### DIFF
--- a/app/Http/Requests/StoreArticleCategoryRequest.php
+++ b/app/Http/Requests/StoreArticleCategoryRequest.php
@@ -22,7 +22,7 @@ class StoreArticleCategoryRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => 'required|string|max:255',
+            'title' => 'required|string|max:255',
             'slug' => 'required|string|max:255|unique:article_categories',
         ];
     }

--- a/app/Http/Requests/UpdateArticleCategoryRequest.php
+++ b/app/Http/Requests/UpdateArticleCategoryRequest.php
@@ -22,7 +22,7 @@ class UpdateArticleCategoryRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => 'required|string|max:255',
+            'title' => 'required|string|max:255',
             'slug' => 'required|string|max:255|unique:article_categories,slug,' . $this->route('article_category')->id,
         ];
     }

--- a/app/Models/ArticleCategory.php
+++ b/app/Models/ArticleCategory.php
@@ -9,7 +9,7 @@ class ArticleCategory extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['name', 'slug', 'description'];
+    protected $fillable = ['title', 'slug', 'description'];
 
     public function articles()
     {

--- a/database/seeders/ArticleSeeder.php
+++ b/database/seeders/ArticleSeeder.php
@@ -4,6 +4,7 @@ namespace Database\Seeders;
 
 use App\Models\Article;
 use App\Models\ArticleCategory;
+use App\Models\Tag;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Str;
 
@@ -12,15 +13,21 @@ class ArticleSeeder extends Seeder
     public function run()
     {
         $categories = ArticleCategory::all(); // Get existing categories
+        $tags = Tag::all();
 
         if ($categories->isEmpty()) {
             $this->call(ArticleCategorySeeder::class); // Ensure categories exist
             $categories = ArticleCategory::all();
         }
 
+        if ($tags->isEmpty()) {
+            $this->call(TagSeeder::class);
+            $tags = Tag::all();
+        }
+
         // Creating articles for each category
         foreach ($categories as $category) {
-            Article::create([
+            $article = Article::create([
                 'title' => "Sample Article in {$category->title}",
                 'slug' => Str::slug("Sample Article in {$category->title}"),
                 'thumbnail' => 'sample-thumbnail.jpg',
@@ -28,6 +35,8 @@ class ArticleSeeder extends Seeder
                 'long_text' => 'This is a long text with more details about the article.',
                 'article_category_id' => $category->id,
             ]);
+
+            $article->tags()->attach($tags->random(3));
         }
     }
 }

--- a/resources/views/admin/article-categories/create.blade.php
+++ b/resources/views/admin/article-categories/create.blade.php
@@ -8,7 +8,7 @@
 
     <form action="{{ route('admin.article-categories.store') }}" method="POST">
         @csrf
-        <x-admin.text-input name="name" label="Name" required />
+        <x-admin.text-input name="title" label="Title" required />
         <x-admin.text-input name="slug" label="Slug" required />
         <x-admin.submit-button label="Create" />
     </form>

--- a/resources/views/admin/article-categories/edit.blade.php
+++ b/resources/views/admin/article-categories/edit.blade.php
@@ -9,7 +9,7 @@
     <form action="{{ route('admin.article-categories.update', $articleCategory) }}" method="POST">
         @csrf
         @method('PUT')
-        <x-admin.text-input name="name" label="Name" :value="$articleCategory->name" required />
+        <x-admin.text-input name="title" label="Title" :value="$articleCategory->title" required />
         <x-admin.text-input name="slug" label="Slug" :value="$articleCategory->slug" required />
         <x-admin.submit-button label="Update" />
     </form>

--- a/resources/views/admin/article-categories/index.blade.php
+++ b/resources/views/admin/article-categories/index.blade.php
@@ -12,7 +12,7 @@
     <table class="w-full bg-white shadow-md rounded-lg">
         <thead>
             <tr class="bg-gray-200">
-                <th class="px-4 py-2">Name</th>
+                <th class="px-4 py-2">Title</th>
                 <th class="px-4 py-2">Slug</th>
                 <th class="px-4 py-2">Actions</th>
             </tr>
@@ -20,7 +20,7 @@
         <tbody>
             @foreach ($articleCategories as $category)
                 <tr>
-                    <td class="border px-4 py-2">{{ $category->name }}</td>
+                    <td class="border px-4 py-2">{{ $category->title }}</td>
                     <td class="border px-4 py-2">{{ $category->slug }}</td>
                     <td class="border px-4 py-2">
                         <a href="{{ route('admin.article-categories.edit', $category) }}" class="text-blue-500 hover:underline">Edit</a>

--- a/resources/views/admin/articles/create.blade.php
+++ b/resources/views/admin/articles/create.blade.php
@@ -17,7 +17,7 @@
         @csrf
         <x-admin.text-input name="title" label="Title" required />
         <x-admin.text-input name="slug" label="Slug" required />
-        <x-admin.select name="article_category_id" label="Category" :options="$categories->pluck('name', 'id')" required />
+        <x-admin.select name="article_category_id" label="Category" :options="$categories->pluck('title', 'id')" required />
         <x-admin.multi-select name="tags" label="Tags" :options="$tags->pluck('name', 'id')" />
         <x-admin.file-input name="thumbnail" label="Thumbnail" />
         <x-admin.textarea name="short_text" label="Short Text" />

--- a/resources/views/admin/articles/edit.blade.php
+++ b/resources/views/admin/articles/edit.blade.php
@@ -11,7 +11,7 @@
         @method('PUT')
         <x-admin.text-input name="title" label="Title" :value="$article->title" required />
         <x-admin.text-input name="slug" label="Slug" :value="$article->slug" required />
-        <x-admin.select name="article_category_id" label="Category" :options="$categories->pluck('name', 'id')" :value="$article->article_category_id" required />
+        <x-admin.select name="article_category_id" label="Category" :options="$categories->pluck('title', 'id')" :value="$article->article_category_id" required />
         <x-admin.multi-select name="tags" label="Tags" :options="$tags->pluck('name', 'id')" :values="$article->tags->pluck('id')->toArray()" />
         <x-admin.file-input name="thumbnail" label="Thumbnail" :value="$article->thumbnail" />
         <x-admin.textarea name="short_text" label="Short Text" :value="$article->short_text" />

--- a/resources/views/frontend/articles/show.blade.php
+++ b/resources/views/frontend/articles/show.blade.php
@@ -6,6 +6,7 @@
 
         <h1 class="w-full lg:w-8/12 heading-text-regular-large  text-secondary-950 mt-20">{{ $article->title }}</h1>
         <div class="mt-7 inline-flex items-center flex-wrap gap-4 ">
+            <div class="hero-badge-desktop">{{ $article->article_category->title }}</div>
             @foreach ($article->tags as $tag)
                 <div class="hero-badge-desktop">{{ $tag->name }}</div>
             @endforeach


### PR DESCRIPTION
This change makes the articles dynamic, with full frontend and admin panel integration.

- Updates the `ArticleCategory` model to use `title` instead of `name` to match the database schema.
- Updates the `ArticleCategory` admin views and form requests to use `title` instead of `name`.
- Updates the `ArticleSeeder` to attach tags to each article.
- Updates the article detail page to display the article's category.