### PR TITLE
Fix: Correct category name inconsistencies

### DIFF
--- a/app/Http/Controllers/Admin/ProjectController.php
+++ b/app/Http/Controllers/Admin/ProjectController.php
@@ -15,7 +15,7 @@ class ProjectController extends Controller
 
     public function index()
     {
-        $projects = Project::with('category')->get();
+        $projects = Project::with('project_category')->get();
         return view('admin.projects.index', compact('projects'));
     }
 

--- a/app/Http/Requests/StoreArticleCategoryRequest.php
+++ b/app/Http/Requests/StoreArticleCategoryRequest.php
@@ -22,8 +22,9 @@ class StoreArticleCategoryRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => 'required|string|max:255',
+            'title' => 'required|string|max:255',
             'slug' => 'required|string|max:255|unique:article_categories',
+            'description' => 'nullable|string',
         ];
     }
 }

--- a/app/Http/Requests/StoreProjectCategoryRequest.php
+++ b/app/Http/Requests/StoreProjectCategoryRequest.php
@@ -22,8 +22,9 @@ class StoreProjectCategoryRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => 'required|string|max:255',
+            'title' => 'required|string|max:255',
             'slug' => 'required|string|max:255|unique:project_categories',
+            'description' => 'nullable|string',
         ];
     }
 }

--- a/app/Http/Requests/StoreServiceCategoryRequest.php
+++ b/app/Http/Requests/StoreServiceCategoryRequest.php
@@ -24,6 +24,7 @@ class StoreServiceCategoryRequest extends FormRequest
         return [
             'title' => 'required|string|max:255',
             'slug' => 'required|string|max:255|unique:service_categories',
+            'description' => 'nullable|string',
         ];
     }
 }

--- a/app/Http/Requests/StoreSoftwareCategoryRequest.php
+++ b/app/Http/Requests/StoreSoftwareCategoryRequest.php
@@ -22,8 +22,9 @@ class StoreSoftwareCategoryRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => 'required|string|max:255',
+            'title' => 'required|string|max:255',
             'slug' => 'required|string|max:255|unique:software_categories',
+            'description' => 'nullable|string',
         ];
     }
 }

--- a/app/Http/Requests/StoreVacancyCategoryRequest.php
+++ b/app/Http/Requests/StoreVacancyCategoryRequest.php
@@ -22,8 +22,9 @@ class StoreVacancyCategoryRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => 'required|string|max:255',
+            'title' => 'required|string|max:255',
             'slug' => 'required|string|max:255|unique:vacancy_categories',
+            'description' => 'nullable|string',
         ];
     }
 }

--- a/app/Http/Requests/UpdateArticleCategoryRequest.php
+++ b/app/Http/Requests/UpdateArticleCategoryRequest.php
@@ -22,8 +22,9 @@ class UpdateArticleCategoryRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => 'required|string|max:255',
+            'title' => 'required|string|max:255',
             'slug' => 'required|string|max:255|unique:article_categories,slug,' . $this->route('article_category')->id,
+            'description' => 'nullable|string',
         ];
     }
 }

--- a/app/Http/Requests/UpdateProjectCategoryRequest.php
+++ b/app/Http/Requests/UpdateProjectCategoryRequest.php
@@ -22,8 +22,9 @@ class UpdateProjectCategoryRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => 'required|string|max:255',
+            'title' => 'required|string|max:255',
             'slug' => 'required|string|max:255|unique:project_categories,slug,' . $this->route('project_category')->id,
+            'description' => 'nullable|string',
         ];
     }
 }

--- a/app/Http/Requests/UpdateServiceCategoryRequest.php
+++ b/app/Http/Requests/UpdateServiceCategoryRequest.php
@@ -22,8 +22,9 @@ class UpdateServiceCategoryRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => 'required|string|max:255',
+            'title' => 'required|string|max:255',
             'slug' => 'required|string|max:255|unique:service_categories,slug,' . $this->route('service_category')->id,
+            'description' => 'nullable|string',
         ];
     }
 }

--- a/app/Http/Requests/UpdateSoftwareCategoryRequest.php
+++ b/app/Http/Requests/UpdateSoftwareCategoryRequest.php
@@ -22,8 +22,9 @@ class UpdateSoftwareCategoryRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => 'required|string|max:255',
+            'title' => 'required|string|max:255',
             'slug' => 'required|string|max:255|unique:software_categories,slug,' . $this->route('software_category')->id,
+            'description' => 'nullable|string',
         ];
     }
 }

--- a/app/Http/Requests/UpdateVacancyCategoryRequest.php
+++ b/app/Http/Requests/UpdateVacancyCategoryRequest.php
@@ -22,8 +22,9 @@ class UpdateVacancyCategoryRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => 'required|string|max:255',
+            'title' => 'required|string|max:255',
             'slug' => 'required|string|max:255|unique:vacancy_categories,slug,' . $this->route('vacancy_category')->id,
+            'description' => 'nullable|string',
         ];
     }
 }

--- a/app/Models/ArticleCategory.php
+++ b/app/Models/ArticleCategory.php
@@ -9,7 +9,7 @@ class ArticleCategory extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['name', 'slug', 'description'];
+    protected $fillable = ['title', 'slug', 'description'];
 
     public function articles()
     {

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -34,7 +34,7 @@ class Project extends Model
     ];
 
     // Relationship with ProjectCategory
-    public function category()
+    public function project_category()
     {
         return $this->belongsTo(ProjectCategory::class, 'project_category_id');
     }

--- a/resources/views/admin/article-categories/create.blade.php
+++ b/resources/views/admin/article-categories/create.blade.php
@@ -8,7 +8,7 @@
 
     <form action="{{ route('admin.article-categories.store') }}" method="POST">
         @csrf
-        <x-admin.text-input name="name" label="Name" required />
+        <x-admin.text-input name="title" label="Title" required />
         <x-admin.text-input name="slug" label="Slug" required />
         <x-admin.submit-button label="Create" />
     </form>

--- a/resources/views/admin/article-categories/edit.blade.php
+++ b/resources/views/admin/article-categories/edit.blade.php
@@ -9,7 +9,7 @@
     <form action="{{ route('admin.article-categories.update', $articleCategory) }}" method="POST">
         @csrf
         @method('PUT')
-        <x-admin.text-input name="name" label="Name" :value="$articleCategory->name" required />
+        <x-admin.text-input name="title" label="Title" :value="$articleCategory->title" required />
         <x-admin.text-input name="slug" label="Slug" :value="$articleCategory->slug" required />
         <x-admin.submit-button label="Update" />
     </form>

--- a/resources/views/admin/article-categories/index.blade.php
+++ b/resources/views/admin/article-categories/index.blade.php
@@ -12,7 +12,7 @@
     <table class="w-full bg-white shadow-md rounded-lg">
         <thead>
             <tr class="bg-gray-200">
-                <th class="px-4 py-2">Name</th>
+                <th class="px-4 py-2">Title</th>
                 <th class="px-4 py-2">Slug</th>
                 <th class="px-4 py-2">Actions</th>
             </tr>
@@ -20,7 +20,7 @@
         <tbody>
             @foreach ($articleCategories as $category)
                 <tr>
-                    <td class="border px-4 py-2">{{ $category->name }}</td>
+                    <td class="border px-4 py-2">{{ $category->title }}</td>
                     <td class="border px-4 py-2">{{ $category->slug }}</td>
                     <td class="border px-4 py-2">
                         <a href="{{ route('admin.article-categories.edit', $category) }}" class="text-blue-500 hover:underline">Edit</a>

--- a/resources/views/admin/project-categories/create.blade.php
+++ b/resources/views/admin/project-categories/create.blade.php
@@ -8,7 +8,7 @@
 
     <form action="{{ route('admin.project-categories.store') }}" method="POST">
         @csrf
-        <x-admin.text-input name="name" label="Name" required />
+        <x-admin.text-input name="title" label="Title" required />
         <x-admin.text-input name="slug" label="Slug" required />
         <x-admin.submit-button label="Create" />
     </form>

--- a/resources/views/admin/project-categories/edit.blade.php
+++ b/resources/views/admin/project-categories/edit.blade.php
@@ -9,7 +9,7 @@
     <form action="{{ route('admin.project-categories.update', $projectCategory) }}" method="POST">
         @csrf
         @method('PUT')
-        <x-admin.text-input name="name" label="Name" :value="$projectCategory->name" required />
+        <x-admin.text-input name="title" label="Title" :value="$projectCategory->title" required />
         <x-admin.text-input name="slug" label="Slug" :value="$projectCategory->slug" required />
         <x-admin.submit-button label="Update" />
     </form>

--- a/resources/views/admin/project-categories/index.blade.php
+++ b/resources/views/admin/project-categories/index.blade.php
@@ -12,7 +12,7 @@
     <table class="w-full bg-white shadow-md rounded-lg">
         <thead>
             <tr class="bg-gray-200">
-                <th class="px-4 py-2">Name</th>
+                <th class="px-4 py-2">Title</th>
                 <th class="px-4 py-2">Slug</th>
                 <th class="px-4 py-2">Actions</th>
             </tr>
@@ -20,7 +20,7 @@
         <tbody>
             @foreach ($projectCategories as $category)
                 <tr>
-                    <td class="border px-4 py-2">{{ $category->name }}</td>
+                    <td class="border px-4 py-2">{{ $category->title }}</td>
                     <td class="border px-4 py-2">{{ $category->slug }}</td>
                     <td class="border px-4 py-2">
                         <a href="{{ route('admin.project-categories.edit', $category) }}" class="text-blue-500 hover:underline">Edit</a>

--- a/resources/views/admin/projects/create.blade.php
+++ b/resources/views/admin/projects/create.blade.php
@@ -10,7 +10,7 @@
         @csrf
         <x-admin.text-input name="title" label="Title" required />
         <x-admin.text-input name="slug" label="Slug" required />
-        <x-admin.select name="project_category_id" label="Category" :options="$categories->pluck('name', 'id')" required />
+        <x-admin.select name="project_category_id" label="Category" :options="$categories->pluck('title', 'id')" required />
         <x-admin.file-input name="thumbnail" label="Thumbnail" />
         <x-admin.submit-button label="Create" />
     </form>

--- a/resources/views/admin/projects/edit.blade.php
+++ b/resources/views/admin/projects/edit.blade.php
@@ -11,7 +11,7 @@
         @method('PUT')
         <x-admin.text-input name="title" label="Title" :value="$project->title" required />
         <x-admin.text-input name="slug" label="Slug" :value="$project->slug" required />
-        <x-admin.select name="project_category_id" label="Category" :options="$categories->pluck('name', 'id')" :value="$project->project_category_id" required />
+        <x-admin.select name="project_category_id" label="Category" :options="$categories->pluck('title', 'id')" :value="$project->project_category_id" required />
         <x-admin.file-input name="thumbnail" label="Thumbnail" :value="$project->thumbnail" />
         <x-admin.submit-button label="Update" />
     </form>

--- a/resources/views/admin/projects/index.blade.php
+++ b/resources/views/admin/projects/index.blade.php
@@ -22,7 +22,7 @@
             @foreach ($projects as $project)
                 <tr>
                     <td class="border px-4 py-2">{{ $project->title }}</td>
-                    <td class="border px-4 py-2">{{ $project->project_category->name }}</td>
+                    <td class="border px-4 py-2">{{ $project->project_category->title }}</td>
                     <td class="border px-4 py-2">
                         @if ($project->thumbnail)
                             <img src="{{ asset('storage/' . $project->thumbnail) }}" alt="{{ $project->title }}" class="h-16 w-16 object-cover">

--- a/resources/views/admin/projects/show.blade.php
+++ b/resources/views/admin/projects/show.blade.php
@@ -6,14 +6,14 @@
 @section('content')
     <div class="p-6 bg-white shadow-md rounded-lg">
         <div class="mb-4">
-            <h2 class="text-2xl font-bold">{{ $project->name }}</h2>
+            <h2 class="text-2xl font-bold">{{ $project->title }}</h2>
         </div>
         <div class="mb-4">
-            <strong>Category:</strong> {{ $project->category->name }}
+            <strong>Category:</strong> {{ $project->project_category->title }}
         </div>
         @if ($project->thumbnail)
             <div class="mb-4">
-                <img src="{{ asset('storage/' . $project->thumbnail) }}" alt="{{ $project->name }}"
+                <img src="{{ asset('storage/' . $project->thumbnail) }}" alt="{{ $project->title }}"
                     class="h-48 w-full object-cover">
             </div>
         @endif

--- a/resources/views/admin/service-categories/edit.blade.php
+++ b/resources/views/admin/service-categories/edit.blade.php
@@ -9,7 +9,7 @@
     <form action="{{ route('admin.service-categories.update', $serviceCategory) }}" method="POST">
         @csrf
         @method('PUT')
-        <x-admin.text-input name="name" label="Name" :value="$serviceCategory->name" required />
+        <x-admin.text-input name="title" label="Title" :value="$serviceCategory->title" required />
         <x-admin.text-input name="slug" label="Slug" :value="$serviceCategory->slug" required />
         <x-admin.submit-button label="Update" />
     </form>

--- a/resources/views/admin/service-categories/index.blade.php
+++ b/resources/views/admin/service-categories/index.blade.php
@@ -12,7 +12,7 @@
     <table class="w-full bg-white shadow-md rounded-lg">
         <thead>
             <tr class="bg-gray-200">
-                <th class="px-4 py-2">Name</th>
+                <th class="px-4 py-2">Title</th>
                 <th class="px-4 py-2">Slug</th>
                 <th class="px-4 py-2">Actions</th>
             </tr>

--- a/resources/views/admin/software-categories/create.blade.php
+++ b/resources/views/admin/software-categories/create.blade.php
@@ -8,7 +8,7 @@
 
     <form action="{{ route('admin.software-categories.store') }}" method="POST">
         @csrf
-        <x-admin.text-input name="name" label="Name" required />
+        <x-admin.text-input name="title" label="Title" required />
         <x-admin.text-input name="slug" label="Slug" required />
         <x-admin.submit-button label="Create" />
     </form>

--- a/resources/views/admin/software-categories/edit.blade.php
+++ b/resources/views/admin/software-categories/edit.blade.php
@@ -9,7 +9,7 @@
     <form action="{{ route('admin.software-categories.update', $softwareCategory) }}" method="POST">
         @csrf
         @method('PUT')
-        <x-admin.text-input name="name" label="Name" :value="$softwareCategory->name" required />
+        <x-admin.text-input name="title" label="Title" :value="$softwareCategory->title" required />
         <x-admin.text-input name="slug" label="Slug" :value="$softwareCategory->slug" required />
         <x-admin.submit-button label="Update" />
     </form>

--- a/resources/views/admin/software-categories/index.blade.php
+++ b/resources/views/admin/software-categories/index.blade.php
@@ -12,7 +12,7 @@
     <table class="w-full bg-white shadow-md rounded-lg">
         <thead>
             <tr class="bg-gray-200">
-                <th class="px-4 py-2">Name</th>
+                <th class="px-4 py-2">Title</th>
                 <th class="px-4 py-2">Slug</th>
                 <th class="px-4 py-2">Actions</th>
             </tr>
@@ -20,7 +20,7 @@
         <tbody>
             @foreach ($softwareCategories as $category)
                 <tr>
-                    <td class="border px-4 py-2">{{ $category->name }}</td>
+                    <td class="border px-4 py-2">{{ $category->title }}</td>
                     <td class="border px-4 py-2">{{ $category->slug }}</td>
                     <td class="border px-4 py-2">
                         <a href="{{ route('admin.software-categories.edit', $category) }}" class="text-blue-500 hover:underline">Edit</a>

--- a/resources/views/admin/vacancy-categories/create.blade.php
+++ b/resources/views/admin/vacancy-categories/create.blade.php
@@ -8,7 +8,7 @@
 
     <form action="{{ route('admin.vacancy-categories.store') }}" method="POST">
         @csrf
-        <x-admin.text-input name="name" label="Name" required />
+        <x-admin.text-input name="title" label="Title" required />
         <x-admin.text-input name="slug" label="Slug" required />
         <x-admin.submit-button label="Create" />
     </form>

--- a/resources/views/admin/vacancy-categories/edit.blade.php
+++ b/resources/views/admin/vacancy-categories/edit.blade.php
@@ -9,7 +9,7 @@
     <form action="{{ route('admin.vacancy-categories.update', $vacancyCategory) }}" method="POST">
         @csrf
         @method('PUT')
-        <x-admin.text-input name="name" label="Name" :value="$vacancyCategory->name" required />
+        <x-admin.text-input name="title" label="Title" :value="$vacancyCategory->title" required />
         <x-admin.text-input name="slug" label="Slug" :value="$vacancyCategory->slug" required />
         <x-admin.submit-button label="Update" />
     </form>

--- a/resources/views/admin/vacancy-categories/index.blade.php
+++ b/resources/views/admin/vacancy-categories/index.blade.php
@@ -12,7 +12,7 @@
     <table class="w-full bg-white shadow-md rounded-lg">
         <thead>
             <tr class="bg-gray-200">
-                <th class="px-4 py-2">Name</th>
+                <th class="px-4 py-2">Title</th>
                 <th class="px-4 py-2">Slug</th>
                 <th class="px-4 py-2">Actions</th>
             </tr>
@@ -20,7 +20,7 @@
         <tbody>
             @foreach ($vacancyCategories as $category)
                 <tr>
-                    <td class="border px-4 py-2">{{ $category->name }}</td>
+                    <td class="border px-4 py-2">{{ $category->title }}</td>
                     <td class="border px-4 py-2">{{ $category->slug }}</td>
                     <td class="border px-4 py-2">
                         <a href="{{ route('admin.vacancy-categories.edit', $category) }}" class="text-blue-500 hover:underline">Edit</a>


### PR DESCRIPTION
This commit fixes inconsistencies in the admin panel where category names were referred to as `name` instead of `title`.

- Updated the `ArticleCategory` model to use `title` in its `$fillable` property.
- Corrected the use of `name` to `title` in the admin views and Form Request classes for `ArticleCategory`, `ServiceCategory`, `ProjectCategory`, `SoftwareCategory`, and `VacancyCategory`.
- Updated the validation rules to include `description`.
- Renamed the `category` relationship on the `Project` model to `project_category` for consistency and updated all usages of it.