### PR TITLE
Refactor slug generation to be automatic for all models.

### DIFF
--- a/app/Http/Requests/StoreArticleCategoryRequest.php
+++ b/app/Http/Requests/StoreArticleCategoryRequest.php
@@ -23,7 +23,6 @@ class StoreArticleCategoryRequest extends FormRequest
     {
         return [
             'title' => 'required|string|max:255',
-            'slug' => 'required|string|max:255|unique:article_categories',
             'description' => 'nullable|string',
         ];
     }

--- a/app/Http/Requests/StoreArticleRequest.php
+++ b/app/Http/Requests/StoreArticleRequest.php
@@ -23,7 +23,6 @@ class StoreArticleRequest extends FormRequest
     {
         return [
             'title' => 'required|string|max:255',
-            'slug' => 'required|string|max:255|unique:articles',
             'article_category_id' => 'required|exists:article_categories,id',
             'thumbnail' => 'nullable|image|mimes:jpeg,png,jpg,gif,svg|max:2048',
             'short_text' => 'nullable|string',

--- a/app/Http/Requests/StoreProjectCategoryRequest.php
+++ b/app/Http/Requests/StoreProjectCategoryRequest.php
@@ -23,7 +23,6 @@ class StoreProjectCategoryRequest extends FormRequest
     {
         return [
             'title' => 'required|string|max:255',
-            'slug' => 'required|string|max:255|unique:project_categories',
             'description' => 'nullable|string',
         ];
     }

--- a/app/Http/Requests/StoreProjectRequest.php
+++ b/app/Http/Requests/StoreProjectRequest.php
@@ -23,7 +23,6 @@ class StoreProjectRequest extends FormRequest
     {
         return [
             'title' => 'required|string|max:255',
-            'slug' => 'required|string|max:255|unique:projects',
             'project_category_id' => 'required|exists:project_categories,id',
             'thumbnail' => 'nullable|image|mimes:jpeg,png,jpg,gif,svg|max:2048',
         ];

--- a/app/Http/Requests/StoreServiceCategoryRequest.php
+++ b/app/Http/Requests/StoreServiceCategoryRequest.php
@@ -23,7 +23,6 @@ class StoreServiceCategoryRequest extends FormRequest
     {
         return [
             'title' => 'required|string|max:255',
-            'slug' => 'required|string|max:255|unique:service_categories',
             'description' => 'nullable|string',
         ];
     }

--- a/app/Http/Requests/StoreServiceRequest.php
+++ b/app/Http/Requests/StoreServiceRequest.php
@@ -23,7 +23,6 @@ class StoreServiceRequest extends FormRequest
     {
         return [
             'name' => 'required|string|max:255',
-            'slug' => 'required|string|max:255|unique:services',
             'service_category_id' => 'required|exists:service_categories,id',
             'description' => 'nullable|string',
             'image' => 'nullable|image|mimes:jpeg,png,jpg,gif,svg|max:2048',

--- a/app/Http/Requests/StoreSoftwareCategoryRequest.php
+++ b/app/Http/Requests/StoreSoftwareCategoryRequest.php
@@ -23,7 +23,6 @@ class StoreSoftwareCategoryRequest extends FormRequest
     {
         return [
             'title' => 'required|string|max:255',
-            'slug' => 'required|string|max:255|unique:software_categories',
             'description' => 'nullable|string',
         ];
     }

--- a/app/Http/Requests/StoreSoftwareRequest.php
+++ b/app/Http/Requests/StoreSoftwareRequest.php
@@ -23,7 +23,6 @@ class StoreSoftwareRequest extends FormRequest
     {
         return [
             'name' => 'required|string|max:255',
-            'slug' => 'required|string|max:255|unique:softwares',
             'software_category_id' => 'required|exists:software_categories,id',
             'image' => 'nullable|image|mimes:jpeg,png,jpg,gif,svg|max:2048',
         ];

--- a/app/Http/Requests/StoreVacancyCategoryRequest.php
+++ b/app/Http/Requests/StoreVacancyCategoryRequest.php
@@ -23,7 +23,6 @@ class StoreVacancyCategoryRequest extends FormRequest
     {
         return [
             'title' => 'required|string|max:255',
-            'slug' => 'required|string|max:255|unique:vacancy_categories',
             'description' => 'nullable|string',
         ];
     }

--- a/app/Http/Requests/StoreVacancyRequest.php
+++ b/app/Http/Requests/StoreVacancyRequest.php
@@ -23,7 +23,6 @@ class StoreVacancyRequest extends FormRequest
     {
         return [
             'title' => 'required|string|max:255',
-            'slug' => 'required|string|max:255|unique:vacancies',
             'vacancy_category_id' => 'required|exists:vacancy_categories,id',
             'type' => 'nullable|string',
             'location' => 'nullable|string',

--- a/app/Http/Requests/UpdateArticleCategoryRequest.php
+++ b/app/Http/Requests/UpdateArticleCategoryRequest.php
@@ -23,7 +23,6 @@ class UpdateArticleCategoryRequest extends FormRequest
     {
         return [
             'title' => 'required|string|max:255',
-            'slug' => 'required|string|max:255|unique:article_categories,slug,' . $this->route('article_category')->id,
             'description' => 'nullable|string',
         ];
     }

--- a/app/Http/Requests/UpdateArticleRequest.php
+++ b/app/Http/Requests/UpdateArticleRequest.php
@@ -23,7 +23,6 @@ class UpdateArticleRequest extends FormRequest
     {
         return [
             'title' => 'required|string|max:255',
-            'slug' => 'required|string|max:255|unique:articles,slug,' . $this->route('article')->id,
             'article_category_id' => 'required|exists:article_categories,id',
             'thumbnail' => 'nullable|image|mimes:jpeg,png,jpg,gif,svg|max:2048',
             'short_text' => 'nullable|string',

--- a/app/Http/Requests/UpdateProjectCategoryRequest.php
+++ b/app/Http/Requests/UpdateProjectCategoryRequest.php
@@ -23,7 +23,6 @@ class UpdateProjectCategoryRequest extends FormRequest
     {
         return [
             'title' => 'required|string|max:255',
-            'slug' => 'required|string|max:255|unique:project_categories,slug,' . $this->route('project_category')->id,
             'description' => 'nullable|string',
         ];
     }

--- a/app/Http/Requests/UpdateProjectRequest.php
+++ b/app/Http/Requests/UpdateProjectRequest.php
@@ -23,7 +23,6 @@ class UpdateProjectRequest extends FormRequest
     {
         return [
             'title' => 'required|string|max:255',
-            'slug' => 'required|string|max:255|unique:projects,slug,' . $this->route('project')->id,
             'project_category_id' => 'required|exists:project_categories,id',
             'thumbnail' => 'nullable|image|mimes:jpeg,png,jpg,gif,svg|max:2048',
         ];

--- a/app/Http/Requests/UpdateServiceCategoryRequest.php
+++ b/app/Http/Requests/UpdateServiceCategoryRequest.php
@@ -23,7 +23,6 @@ class UpdateServiceCategoryRequest extends FormRequest
     {
         return [
             'title' => 'required|string|max:255',
-            'slug' => 'required|string|max:255|unique:service_categories,slug,' . $this->route('service_category')->id,
             'description' => 'nullable|string',
         ];
     }

--- a/app/Http/Requests/UpdateServiceRequest.php
+++ b/app/Http/Requests/UpdateServiceRequest.php
@@ -23,7 +23,6 @@ class UpdateServiceRequest extends FormRequest
     {
         return [
             'name' => 'required|string|max:255',
-            'slug' => 'required|string|max:255|unique:services,slug,' . $this->route('service')->id,
             'service_category_id' => 'required|exists:service_categories,id',
             'description' => 'nullable|string',
             'image' => 'nullable|image|mimes:jpeg,png,jpg,gif,svg|max:2048',

--- a/app/Http/Requests/UpdateSoftwareCategoryRequest.php
+++ b/app/Http/Requests/UpdateSoftwareCategoryRequest.php
@@ -23,7 +23,6 @@ class UpdateSoftwareCategoryRequest extends FormRequest
     {
         return [
             'title' => 'required|string|max:255',
-            'slug' => 'required|string|max:255|unique:software_categories,slug,' . $this->route('software_category')->id,
             'description' => 'nullable|string',
         ];
     }

--- a/app/Http/Requests/UpdateSoftwareRequest.php
+++ b/app/Http/Requests/UpdateSoftwareRequest.php
@@ -23,7 +23,6 @@ class UpdateSoftwareRequest extends FormRequest
     {
         return [
             'name' => 'required|string|max:255',
-            'slug' => 'required|string|max:255|unique:softwares,slug,' . $this->route('software')->id,
             'software_category_id' => 'required|exists:software_categories,id',
             'image' => 'nullable|image|mimes:jpeg,png,jpg,gif,svg|max:2048',
         ];

--- a/app/Http/Requests/UpdateVacancyCategoryRequest.php
+++ b/app/Http/Requests/UpdateVacancyCategoryRequest.php
@@ -23,7 +23,6 @@ class UpdateVacancyCategoryRequest extends FormRequest
     {
         return [
             'title' => 'required|string|max:255',
-            'slug' => 'required|string|max:255|unique:vacancy_categories,slug,' . $this->route('vacancy_category')->id,
             'description' => 'nullable|string',
         ];
     }

--- a/app/Http/Requests/UpdateVacancyRequest.php
+++ b/app/Http/Requests/UpdateVacancyRequest.php
@@ -23,7 +23,6 @@ class UpdateVacancyRequest extends FormRequest
     {
         return [
             'title' => 'required|string|max:255',
-            'slug' => 'required|string|max:255|unique:vacancies,slug,' . $this->route('vacancy')->id,
             'vacancy_category_id' => 'required|exists:vacancy_categories,id',
             'type' => 'nullable|string',
             'location' => 'nullable|string',

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -2,12 +2,13 @@
 
 namespace App\Models;
 
+use App\Traits\HasSlug;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Article extends Model
 {
-    use HasFactory;
+    use HasFactory, HasSlug;
 
     protected $fillable = ['title', 'slug', 'short_text', 'long_text', 'article_category_id', 'thumbnail'];
 

--- a/app/Models/ArticleCategory.php
+++ b/app/Models/ArticleCategory.php
@@ -2,12 +2,13 @@
 
 namespace App\Models;
 
+use App\Traits\HasSlug;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class ArticleCategory extends Model
 {
-    use HasFactory;
+    use HasFactory, HasSlug;
 
     protected $fillable = ['title', 'slug', 'description'];
 

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -2,12 +2,13 @@
 
 namespace App\Models;
 
+use App\Traits\HasSlug;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Project extends Model
 {
-    use HasFactory;
+    use HasFactory, HasSlug;
 
     protected $fillable = [
         'title',

--- a/app/Models/ProjectCategory.php
+++ b/app/Models/ProjectCategory.php
@@ -2,12 +2,13 @@
 
 namespace App\Models;
 
+use App\Traits\HasSlug;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class ProjectCategory extends Model
 {
-    use HasFactory;
+    use HasFactory, HasSlug;
 
     protected $fillable = ['title', 'slug', 'description'];
 

--- a/app/Models/Service.php
+++ b/app/Models/Service.php
@@ -2,12 +2,13 @@
 
 namespace App\Models;
 
+use App\Traits\HasSlug;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Service extends Model
 {
-    use HasFactory;
+    use HasFactory, HasSlug;
 
     protected $fillable = [
         'name',
@@ -16,6 +17,11 @@ class Service extends Model
         'description',
         'image',
     ];
+
+    public function getSlugSourceField(): string
+    {
+        return 'name';
+    }
 
     public function service_category()
     {

--- a/app/Models/ServiceCategory.php
+++ b/app/Models/ServiceCategory.php
@@ -2,12 +2,13 @@
 
 namespace App\Models;
 
+use App\Traits\HasSlug;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class ServiceCategory extends Model
 {
-    use HasFactory;
+    use HasFactory, HasSlug;
 
     protected $fillable = ['title', 'slug', 'description'];
 

--- a/app/Models/Software.php
+++ b/app/Models/Software.php
@@ -2,12 +2,13 @@
 
 namespace App\Models;
 
+use App\Traits\HasSlug;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Software extends Model
 {
-    use HasFactory;
+    use HasFactory, HasSlug;
 
     protected $table = 'softwares';
 
@@ -17,6 +18,11 @@ class Software extends Model
         'software_category_id',
         'image',
     ];
+
+    public function getSlugSourceField(): string
+    {
+        return 'name';
+    }
 
     public function software_category()
     {

--- a/app/Models/SoftwareCategory.php
+++ b/app/Models/SoftwareCategory.php
@@ -2,12 +2,13 @@
 
 namespace App\Models;
 
+use App\Traits\HasSlug;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class SoftwareCategory extends Model
 {
-    use HasFactory;
+    use HasFactory, HasSlug;
 
     protected $fillable = ['title', 'slug', 'description'];
 

--- a/app/Models/Vacancy.php
+++ b/app/Models/Vacancy.php
@@ -2,12 +2,13 @@
 
 namespace App\Models;
 
+use App\Traits\HasSlug;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Vacancy extends Model
 {
-    use HasFactory;
+    use HasFactory, HasSlug;
 
     protected $fillable = ['title', 'slug', 'type', 'location', 'end_date', 'benefits', 'responsibilities', 'requirements', 'skills_required', 'weekly_holidays', 'salary', 'others', 'vacancy_category_id'];
 

--- a/app/Models/VacancyCategory.php
+++ b/app/Models/VacancyCategory.php
@@ -2,12 +2,13 @@
 
 namespace App\Models;
 
+use App\Traits\HasSlug;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class VacancyCategory extends Model
 {
-    use HasFactory;
+    use HasFactory, HasSlug;
 
     protected $table = 'vacancy_categories';
 

--- a/app/Traits/HasSlug.php
+++ b/app/Traits/HasSlug.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+
+trait HasSlug
+{
+    /**
+     * Boot the trait.
+     *
+     * @return void
+     */
+    protected static function bootHasSlug()
+    {
+        static::creating(function (Model $model) {
+            if (empty($model->slug)) {
+                $model->slug = $model->generateUniqueSlug($model->{$model->getSlugSourceField()});
+            }
+        });
+
+        static::updating(function (Model $model) {
+            if ($model->isDirty($model->getSlugSourceField())) {
+                $model->slug = $model->generateUniqueSlug($model->{$model->getSlugSourceField()});
+            }
+        });
+    }
+
+    /**
+     * Get the source field for the slug.
+     *
+     * @return string
+     */
+    public function getSlugSourceField(): string
+    {
+        return 'title';
+    }
+
+    /**
+     * Generate a unique slug for the model.
+     *
+     * @param  string  $source
+     * @return string
+     */
+    protected function generateUniqueSlug(string $source): string
+    {
+        $slug = Str::slug($source);
+        $originalSlug = $slug;
+        $count = 1;
+
+        while (static::where('slug', $slug)->when($this->exists, fn ($q) => $q->where($this->getKeyName(), '!=', $this->getKey()))->exists()) {
+            $slug = "{$originalSlug}-{$count}";
+            $count++;
+        }
+
+        return $slug;
+    }
+}

--- a/resources/views/admin/article-categories/create.blade.php
+++ b/resources/views/admin/article-categories/create.blade.php
@@ -9,7 +9,6 @@
     <form action="{{ route('admin.article-categories.store') }}" method="POST">
         @csrf
         <x-admin.text-input name="title" label="Title" required />
-        <x-admin.text-input name="slug" label="Slug" required />
         <x-admin.submit-button label="Create" />
     </form>
 @endsection

--- a/resources/views/admin/article-categories/edit.blade.php
+++ b/resources/views/admin/article-categories/edit.blade.php
@@ -10,7 +10,6 @@
         @csrf
         @method('PUT')
         <x-admin.text-input name="title" label="Title" :value="$articleCategory->title" required />
-        <x-admin.text-input name="slug" label="Slug" :value="$articleCategory->slug" required />
         <x-admin.submit-button label="Update" />
     </form>
 @endsection

--- a/resources/views/admin/articles/create.blade.php
+++ b/resources/views/admin/articles/create.blade.php
@@ -16,7 +16,6 @@
     <form action="{{ route('admin.articles.store') }}" method="POST" enctype="multipart/form-data">
         @csrf
         <x-admin.text-input name="title" label="Title" required />
-        <x-admin.text-input name="slug" label="Slug" required />
         <x-admin.select name="article_category_id" label="Category" :options="$categories->pluck('title', 'id')" required />
         <x-admin.multi-select name="tags" label="Tags" :options="$tags->pluck('name', 'id')" />
         <x-admin.file-input name="thumbnail" label="Thumbnail" />

--- a/resources/views/admin/articles/edit.blade.php
+++ b/resources/views/admin/articles/edit.blade.php
@@ -10,7 +10,6 @@
         @csrf
         @method('PUT')
         <x-admin.text-input name="title" label="Title" :value="$article->title" required />
-        <x-admin.text-input name="slug" label="Slug" :value="$article->slug" required />
         <x-admin.select name="article_category_id" label="Category" :options="$categories->pluck('title', 'id')" :value="$article->article_category_id" required />
         <x-admin.multi-select name="tags" label="Tags" :options="$tags->pluck('name', 'id')" :values="$article->tags->pluck('id')->toArray()" />
         <x-admin.file-input name="thumbnail" label="Thumbnail" :value="$article->thumbnail" />

--- a/resources/views/admin/project-categories/create.blade.php
+++ b/resources/views/admin/project-categories/create.blade.php
@@ -9,7 +9,6 @@
     <form action="{{ route('admin.project-categories.store') }}" method="POST">
         @csrf
         <x-admin.text-input name="title" label="Title" required />
-        <x-admin.text-input name="slug" label="Slug" required />
         <x-admin.submit-button label="Create" />
     </form>
 @endsection

--- a/resources/views/admin/project-categories/edit.blade.php
+++ b/resources/views/admin/project-categories/edit.blade.php
@@ -10,7 +10,6 @@
         @csrf
         @method('PUT')
         <x-admin.text-input name="title" label="Title" :value="$projectCategory->title" required />
-        <x-admin.text-input name="slug" label="Slug" :value="$projectCategory->slug" required />
         <x-admin.submit-button label="Update" />
     </form>
 @endsection

--- a/resources/views/admin/projects/create.blade.php
+++ b/resources/views/admin/projects/create.blade.php
@@ -9,7 +9,6 @@
     <form action="{{ route('admin.projects.store') }}" method="POST" enctype="multipart/form-data">
         @csrf
         <x-admin.text-input name="title" label="Title" required />
-        <x-admin.text-input name="slug" label="Slug" required />
         <x-admin.select name="project_category_id" label="Category" :options="$categories->pluck('title', 'id')" required />
         <x-admin.file-input name="thumbnail" label="Thumbnail" />
         <x-admin.submit-button label="Create" />

--- a/resources/views/admin/projects/edit.blade.php
+++ b/resources/views/admin/projects/edit.blade.php
@@ -10,7 +10,6 @@
         @csrf
         @method('PUT')
         <x-admin.text-input name="title" label="Title" :value="$project->title" required />
-        <x-admin.text-input name="slug" label="Slug" :value="$project->slug" required />
         <x-admin.select name="project_category_id" label="Category" :options="$categories->pluck('title', 'id')" :value="$project->project_category_id" required />
         <x-admin.file-input name="thumbnail" label="Thumbnail" :value="$project->thumbnail" />
         <x-admin.submit-button label="Update" />

--- a/resources/views/admin/service-categories/create.blade.php
+++ b/resources/views/admin/service-categories/create.blade.php
@@ -9,7 +9,6 @@
 <form action="{{ route('admin.service-categories.store') }}" method="POST">
     @csrf
     <x-admin.text-input name="title" label="Title" required />
-    <x-admin.text-input name="slug" label="Slug" required />
     <x-admin.submit-button label="Create" />
 </form>
 @endsection

--- a/resources/views/admin/service-categories/edit.blade.php
+++ b/resources/views/admin/service-categories/edit.blade.php
@@ -10,7 +10,6 @@
         @csrf
         @method('PUT')
         <x-admin.text-input name="title" label="Title" :value="$serviceCategory->title" required />
-        <x-admin.text-input name="slug" label="Slug" :value="$serviceCategory->slug" required />
         <x-admin.submit-button label="Update" />
     </form>
 @endsection

--- a/resources/views/admin/services/create.blade.php
+++ b/resources/views/admin/services/create.blade.php
@@ -9,7 +9,6 @@
     <form action="{{ route('admin.services.store') }}" method="POST" enctype="multipart/form-data">
         @csrf
         <x-admin.text-input name="name" label="Name" required />
-        <x-admin.text-input name="slug" label="Slug" required />
         <x-admin.select name="service_category_id" label="Category" :options="$categories->pluck('name', 'id')" required />
         <x-admin.textarea name="description" label="Description" />
         <x-admin.file-input name="image" label="Image" />

--- a/resources/views/admin/services/edit.blade.php
+++ b/resources/views/admin/services/edit.blade.php
@@ -10,7 +10,6 @@
         @csrf
         @method('PUT')
         <x-admin.text-input name="name" label="Name" :value="$service->name" required />
-        <x-admin.text-input name="slug" label="Slug" :value="$service->slug" required />
         <x-admin.select name="service_category_id" label="Category" :options="$categories->pluck('name', 'id')" :value="$service->service_category_id" required />
         <x-admin.textarea name="description" label="Description" :value="$service->description" />
         <x-admin.file-input name="image" label="Image" :value="$service->image" />

--- a/resources/views/admin/software-categories/create.blade.php
+++ b/resources/views/admin/software-categories/create.blade.php
@@ -9,7 +9,6 @@
     <form action="{{ route('admin.software-categories.store') }}" method="POST">
         @csrf
         <x-admin.text-input name="title" label="Title" required />
-        <x-admin.text-input name="slug" label="Slug" required />
         <x-admin.submit-button label="Create" />
     </form>
 @endsection

--- a/resources/views/admin/software-categories/edit.blade.php
+++ b/resources/views/admin/software-categories/edit.blade.php
@@ -10,7 +10,6 @@
         @csrf
         @method('PUT')
         <x-admin.text-input name="title" label="Title" :value="$softwareCategory->title" required />
-        <x-admin.text-input name="slug" label="Slug" :value="$softwareCategory->slug" required />
         <x-admin.submit-button label="Update" />
     </form>
 @endsection

--- a/resources/views/admin/softwares/create.blade.php
+++ b/resources/views/admin/softwares/create.blade.php
@@ -9,7 +9,6 @@
     <form action="{{ route('admin.softwares.store') }}" method="POST" enctype="multipart/form-data">
         @csrf
         <x-admin.text-input name="name" label="Name" required />
-        <x-admin.text-input name="slug" label="Slug" required />
         <x-admin.select name="software_category_id" label="Category" :options="$categories->pluck('name', 'id')" required />
         <x-admin.file-input name="image" label="Image" />
         <x-admin.submit-button label="Create" />

--- a/resources/views/admin/softwares/edit.blade.php
+++ b/resources/views/admin/softwares/edit.blade.php
@@ -10,7 +10,6 @@
         @csrf
         @method('PUT')
         <x-admin.text-input name="name" label="Name" :value="$software->name" required />
-        <x-admin.text-input name="slug" label="Slug" :value="$software->slug" required />
         <x-admin.select name="software_category_id" label="Category" :options="$categories->pluck('name', 'id')" :value="$software->software_category_id" required />
         <x-admin.file-input name="image" label="Image" :value="$software->image" />
         <x-admin.submit-button label="Update" />

--- a/resources/views/admin/vacancies/create.blade.php
+++ b/resources/views/admin/vacancies/create.blade.php
@@ -10,7 +10,6 @@
         @csrf
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
             <x-admin.text-input name="title" label="Title" required />
-            <x-admin.text-input name="slug" label="Slug" required />
             <x-admin.select name="vacancy_category_id" label="Category" :options="$categories->pluck('name', 'id')" required />
             <x-admin.text-input name="type" label="Type" />
             <x-admin.text-input name="location" label="Location" />

--- a/resources/views/admin/vacancies/edit.blade.php
+++ b/resources/views/admin/vacancies/edit.blade.php
@@ -11,7 +11,6 @@
         @method('PATCH')
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
             <x-admin.text-input name="title" label="Title" :value="$vacancy->title" required />
-            <x-admin.text-input name="slug" label="Slug" :value="$vacancy->slug" required />
             <x-admin.select name="vacancy_category_id" label="Category" :options="$categories->pluck('name', 'id')" :value="$vacancy->vacancy_category_id" required />
             <x-admin.text-input name="type" label="Type" :value="$vacancy->type" />
             <x-admin.text-input name="location" label="Location" :value="$vacancy->location" />

--- a/resources/views/admin/vacancy-categories/create.blade.php
+++ b/resources/views/admin/vacancy-categories/create.blade.php
@@ -9,7 +9,6 @@
     <form action="{{ route('admin.vacancy-categories.store') }}" method="POST">
         @csrf
         <x-admin.text-input name="title" label="Title" required />
-        <x-admin.text-input name="slug" label="Slug" required />
         <x-admin.submit-button label="Create" />
     </form>
 @endsection

--- a/resources/views/admin/vacancy-categories/edit.blade.php
+++ b/resources/views/admin/vacancy-categories/edit.blade.php
@@ -10,7 +10,6 @@
         @csrf
         @method('PUT')
         <x-admin.text-input name="title" label="Title" :value="$vacancyCategory->title" required />
-        <x-admin.text-input name="slug" label="Slug" :value="$vacancyCategory->slug" required />
         <x-admin.submit-button label="Update" />
     </form>
 @endsection


### PR DESCRIPTION
This commit extends the `HasSlug` trait to all models that have a `slug` field, including main models (`Article`, `Service`, `Project`, `Software`, `Vacancy`) and their corresponding category models.

- The `HasSlug` trait is now applied to all relevant models.
- The trait was made more flexible to handle `name` as a source field in addition to `title`.
- All corresponding `Store` and `Update` Form Requests have had their slug validation rules removed.
- All corresponding `create.blade.php` and `edit.blade.php` views have had their slug input fields removed.

This change fully automates slug generation across the application, ensuring consistency and improving the user experience for content managers.